### PR TITLE
feat: Add movie markers and credits type/functions

### DIFF
--- a/src/library.types.ts
+++ b/src/library.types.ts
@@ -1,4 +1,4 @@
-import { ChapterSource, MediaTagData } from './video.types.js';
+import { ChapterSource, MediaTagData, MarkerData } from './video.types.js';
 
 export interface LibraryRootResponse {
   size: number;
@@ -116,6 +116,7 @@ export interface MovieData {
   Producer?: MediaTagData[];
   Extras?: ExtrasData[];
   Guid?: Guid[];
+  Marker?: MarkerData[];
 }
 
 export interface MediaTag {

--- a/src/library.types.ts
+++ b/src/library.types.ts
@@ -1,4 +1,4 @@
-import { ChapterSource, MediaTagData, MarkerData } from './video.types.js';
+import { ChapterSource, MarkerData, MediaTagData } from './video.types.js';
 
 export interface LibraryRootResponse {
   size: number;

--- a/src/media.ts
+++ b/src/media.ts
@@ -207,7 +207,7 @@ export class Marker extends MediaTag {
   static override TAG = 'Marker' as const;
   FILTER = 'marker' as const;
 
-  type!: 'intro';
+  type!: 'intro' | 'credits';
   startTimeOffset!: number;
   endTimeOffset!: number;
 

--- a/src/video.ts
+++ b/src/video.ts
@@ -195,10 +195,10 @@ export class Movie extends Video {
     if (!this.isFullObject) {
       await this.reload();
     }
-  
+
     return this.markers.some(marker => marker.type === 'intro');
   }
-  
+
   /**
    * Returns True if this movie has a credits marker
    */
@@ -206,9 +206,9 @@ export class Movie extends Video {
     if (!this.isFullObject) {
       await this.reload();
     }
-  
+
     return this.markers.some(marker => marker.type === 'credits');
-  }  
+  }
 
   protected override _loadData(data: MovieData): void {
     super._loadData(data);
@@ -511,7 +511,7 @@ export class Episode extends Video {
     if (!this.isFullObject) {
       await this.reload();
     }
-  
+
     return this.markers.some(marker => marker.type === 'credits');
   }
 

--- a/src/video.ts
+++ b/src/video.ts
@@ -173,6 +173,7 @@ export class Movie extends Video {
   similar!: Similar[];
   media!: Media[];
   guids!: Guid[];
+  markers!: Marker[];
 
   get actors() {
     return this.roles;
@@ -186,6 +187,28 @@ export class Movie extends Video {
     const parts = (this.media?.map(media => media.parts) ?? []).flat();
     return parts.map(part => part.file);
   }
+
+  /**
+   * Returns True if this movie has an intro marker
+   */
+  async hasIntroMarker(): Promise<boolean> {
+    if (!this.isFullObject) {
+      await this.reload();
+    }
+  
+    return this.markers.some(marker => marker.type === 'intro');
+  }
+  
+  /**
+   * Returns True if this movie has a credits marker
+   */
+  async hasCreditsMarker(): Promise<boolean> {
+    if (!this.isFullObject) {
+      await this.reload();
+    }
+  
+    return this.markers.some(marker => marker.type === 'credits');
+  }  
 
   protected override _loadData(data: MovieData): void {
     super._loadData(data);
@@ -218,6 +241,7 @@ export class Movie extends Video {
     this.producers = data.Producer?.map(d => new Producer(this.server, d, undefined, this)) ?? [];
     this.media = data.Media?.map(d => new Media(this.server, d, undefined, this)) ?? [];
     this.guids = data.Guid?.map(d => new Guid(this.server, d, undefined, this)) ?? [];
+    this.markers = data.Marker?.map(d => new Marker(this.server, d, undefined, this)) ?? [];
   }
 
   protected _loadFullData(data: FullMovieResponse): void {
@@ -478,6 +502,17 @@ export class Episode extends Video {
     }
 
     return this.markers.some(marker => marker.type === 'intro');
+  }
+
+  /**
+   * Returns True if this episode has a credits marker
+   */
+  async hasCreditsMarker(): Promise<boolean> {
+    if (!this.isFullObject) {
+      await this.reload();
+    }
+  
+    return this.markers.some(marker => marker.type === 'credits');
   }
 
   protected override _loadData(data: EpisodeMetadata): void {

--- a/src/video.types.ts
+++ b/src/video.types.ts
@@ -119,7 +119,7 @@ export interface ChapterData extends MediaTagData {
 }
 
 export interface MarkerData extends MediaTagData {
-  type: 'intro';
+  type: 'intro' | 'credits';
   startTimeOffset: number;
   endTimeOffset: number;
 }


### PR DESCRIPTION
This adds markers to the `Movie` class. It also introduces the equally valid "credits" type and appropriate utility functions. I've tested this locally and it has worked.