### PR TITLE
fix: actually compare section ids

### DIFF
--- a/src/library.ts
+++ b/src/library.ts
@@ -71,8 +71,9 @@ export class Library {
   }
 
   async sectionByID(sectionId: string | number): Promise<Section> {
+    const sectionIdStr = sectionId.toString();
     const sections = await this.sections();
-    const section = sections.find(s => s.key);
+    const section = sections.find(s => s.key === sectionIdStr);
     if (!section) {
       throw new Error(`Invalid library section id: ${sectionId}`);
     }


### PR DESCRIPTION
Currently, `sectionByID` doesn't actually compare section keys—it just finds the section with a "truthy" key (which is effectively just the first section in the array). This adds a comparison and converts the ID to a string first to prevent a type mismatch. This has been tested locally and is working.