### PR TITLE
feat: add web login methods

### DIFF
--- a/examples/web-login.ts
+++ b/examples/web-login.ts
@@ -1,0 +1,23 @@
+import { MyPlexAccount } from '../src/index.js';
+
+async function listLibraries(account: MyPlexAccount) {
+  const resource = await account.resource('zeus');
+  const plex = await resource.connect();
+  const library = await plex.library();
+  const sections = await library.sections();
+
+  for (const section of sections) {
+    console.log(`${section.title} - ${section.CONTENT_TYPE}`);
+  }
+}
+
+MyPlexAccount.getWebLogin().then(
+  webLogin => {
+    console.log('Got to', webLogin.uri);
+    MyPlexAccount.webLoginCheck(webLogin).then(
+      account => listLibraries(account).then(
+        () => console.log('done')
+      )
+    );
+  }
+);

--- a/src/myplex.ts
+++ b/src/myplex.ts
@@ -95,12 +95,6 @@ export class MyPlexAccount {
           continue;
         }
 
-        if ((err as Error).message.includes('429')) {
-          // eslint-disable-next-line no-await-in-loop
-          await sleep(recheckMs);
-          continue;
-        }
-
         throw err;
       }
     }

--- a/src/myplex.types.ts
+++ b/src/myplex.types.ts
@@ -134,3 +134,9 @@ export interface Device {
   };
   Connection?: Array<{ $: { uri: string } }>;
 }
+
+export interface WebLogin {
+  id: number;
+  code: string;
+  uri: string;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -63,3 +63,11 @@ export function ltrim(x: string, characters: string[]) {
 export function lowerFirst(str: string) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise<void>(
+    resolve => {
+      setTimeout(() => resolve(), ms);
+    }
+  );
+}


### PR DESCRIPTION
This lets you either present a url for a user to go to, or a url to send them too (if in a webserver context) and then get a token from Plex.

I created an example usage in the `example` directory