### PR TITLE
feat: add Playlist.update() static method for efficient metadata updates

### DIFF
--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -53,6 +53,13 @@ interface CreateSmartPlaylistOptions {
 type CreatePlaylistOptions = CreateRegularPlaylistOptions | CreateSmartPlaylistOptions;
 type PlaylistContent = Episode | Movie;
 
+export interface UpdatePlaylistOptions {
+  /** New title for the playlist */
+  title?: string;
+  /** New summary/description for the playlist */
+  summary?: string;
+}
+
 export class Playlist extends Playable {
   static override TAG = 'Playlist';
 
@@ -63,6 +70,42 @@ export class Playlist extends Playable {
     }
 
     return this._create(server, title, (options as any).items);
+  }
+
+  /**
+   * Update a playlist's metadata by ratingKey without fetching the full playlist first.
+   *
+   * @param server - The Plex server instance
+   * @param ratingKey - The playlist's ratingKey
+   * @param options - Fields to update (title and/or summary)
+   *
+   * @example
+   * ```typescript
+   * await Playlist.update(server, '12345', {
+   *   title: 'My Updated Playlist',
+   *   summary: 'A new description'
+   * });
+   * ```
+   */
+  static async update(
+    server: PlexServer,
+    ratingKey: string,
+    options: UpdatePlaylistOptions,
+  ): Promise<void> {
+    if (!options.title && !options.summary) {
+      return;
+    }
+
+    const params = new URLSearchParams();
+    if (options.title) {
+      params.set('title', options.title);
+    }
+    if (options.summary) {
+      params.set('summary', options.summary);
+    }
+
+    const key = `/playlists/${ratingKey}?${params.toString()}`;
+    await server.query(key, 'put');
   }
 
   /** Create a smart playlist. */

--- a/test/playlist.spec.ts
+++ b/test/playlist.spec.ts
@@ -58,3 +58,25 @@ it('should edit a playlist', async () => {
   expect(playlist.title).toBe(new_title);
   expect(playlist.summary).toBe(new_summary);
 });
+
+it('should update a playlist by ratingKey without fetching it first', async () => {
+  const title = 'test_playlist_static_update';
+  const new_title = 'test_playlist_updated_title';
+  const new_summary = 'Updated via static method';
+
+  // Create playlist
+  playlist = await Playlist.create(plex, title, { items: [buckBunny] });
+  expect(playlist.title).toBe(title);
+  expect(playlist.summary).toBe('');
+
+  // Update using static method with just the ratingKey (no fetch required)
+  await Playlist.update(plex, playlist.ratingKey, {
+    title: new_title,
+    summary: new_summary,
+  });
+
+  // Fetch and verify updates
+  await playlist.reload();
+  expect(playlist.title).toBe(new_title);
+  expect(playlist.summary).toBe(new_summary);
+});


### PR DESCRIPTION
Adds a static `Playlist.update()` method for updating playlist metadata by `ratingKey` without fetching the entire playlist first.

### Problem
Currently, updating playlist metadata requires a two-step process:
```typescript
// Current approach - requires full fetch
const playlist = await plex.playlist(ratingKey);
await playlist.edit({ title: 'New Title', summary: 'New Summary' });
```

This is inefficient when you only want to update metadata and don't need the full playlist object with all its items.

### Solution
Added a static `Playlist.update()` method that updates metadata directly:

```typescript
// New approach - direct update
await Playlist.update(plex, ratingKey, {
  title: 'New Title',
  summary: 'New Summary'
});
```

**Implementation:**
- Added `UpdatePlaylistOptions` interface with `title?: string` and `summary?: string`
- Added static `update(server, ratingKey, options)` method that makes a direct PUT request
- Uses existing Plex API endpoint: `PUT /playlists/{ratingKey}?title=...&summary=...`

### Benefits
- **Performance**: No need to fetch playlist data when only updating metadata
- **Cleaner API**: Direct updates without intermediate object
- **Batch operations**: Easier to update multiple playlists in a loop
- **Lower memory**: No playlist object allocation for metadata-only changes

### Use Cases
1. **Automated playlist management**: Update generated playlist titles/descriptions
2. **Bulk metadata updates**: Update multiple playlists without fetching each one
3. **Scheduled updates**: Refresh playlist descriptions with timestamps

### API Documentation
```typescript
/**
 * Update a playlist's metadata by ratingKey without fetching the full playlist first.
 *
 * @param server - The Plex server instance
 * @param ratingKey - The playlist's ratingKey
 * @param options - Fields to update (title and/or summary)
 *
 * @example
 * await Playlist.update(server, '12345', {
 *   title: 'My Updated Playlist',
 *   summary: 'A new description'
 * });
 */
static async update(
  server: PlexServer,
  ratingKey: string,
  options: UpdatePlaylistOptions,
): Promise<void>
```

### Test Coverage
Added test case verifying:
- ✅ Update playlist title and summary via static method
- ✅ Changes persist (verified via reload)
- ✅ Works without fetching playlist first

### Breaking Changes
None. This is purely additive functionality. Existing `playlist.edit()` method remains unchanged.

### Related Work
- Complements existing `playlist.edit()` instance method
- Similar pattern to other static factory methods in the codebase