### PR TITLE
feat: make query accept single options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ Create a plex connection
 ```ts
 import { MyPlexAccount } from '@ctrl/plex';
 
-const account = await new MyPlexAccount('http://localhost:32400', 'username', 'password').connect();
+const account = await new MyPlexAccount({
+  baseUrl: 'http://localhost:32400',
+  username: 'username',
+  password: 'password',
+}).connect();
 const resource = await account.resource('<SERVERNAME>');
 const plex = await resource.connect();
 const library = await plex.library();

--- a/examples/list-duplicate-movies.ts
+++ b/examples/list-duplicate-movies.ts
@@ -40,12 +40,12 @@ function getQualityScore(parsed: ParsedMovie): number {
 }
 
 async function listDuplicateMovies() {
-  const account = await new MyPlexAccount(
-    null,
-    process.env.PLEX_USERNAME,
-    process.env.PLEX_PASSWORD,
-    process.env.PLEX_TOKEN,
-  ).connect();
+  const account = await new MyPlexAccount({
+    baseUrl: null,
+    username: process.env.PLEX_USERNAME,
+    password: process.env.PLEX_PASSWORD,
+    token: process.env.PLEX_TOKEN,
+  }).connect();
   const resource = await account.resource(RESOURCE_NAME);
   const plex = await resource.connect();
   const library = await plex.library();

--- a/examples/list-movie-ratings.ts
+++ b/examples/list-movie-ratings.ts
@@ -1,11 +1,11 @@
 import { type MovieSection, MyPlexAccount } from '../src/index.js';
 
 async function listMovies() {
-  const account = await new MyPlexAccount(
-    process.env.PLEX_HOST,
-    process.env.PLEX_USERNAME,
-    process.env.PLEX_PASSWORD,
-  ).connect();
+  const account = await new MyPlexAccount({
+    baseUrl: process.env.PLEX_HOST ?? null,
+    username: process.env.PLEX_USERNAME,
+    password: process.env.PLEX_PASSWORD,
+  }).connect();
   const resource = await account.resource('cooper-plex');
   const plex = await resource.connect();
   const library = await plex.library();

--- a/scripts/bootstraptest.ts
+++ b/scripts/bootstraptest.ts
@@ -270,12 +270,12 @@ async function main() {
     throw new Error('Must provide username/password or token');
   }
 
-  const account = await new MyPlexAccount(
-    'http://localhost:32400',
-    argv.username,
-    argv.password,
+  const account = await new MyPlexAccount({
+    baseUrl: 'http://localhost:32400',
+    username: argv.username,
+    password: argv.password,
     token,
-  ).connect();
+  }).connect();
   const claimToken = await account.claimToken();
   const destination = join(__dirname, '..', argv.destination);
   const mediaPath = join(destination, 'media');

--- a/src/alert.ts
+++ b/src/alert.ts
@@ -14,7 +14,7 @@ export class AlertListener {
   ) {}
 
   async run(): Promise<void> {
-    const url = this.server.url(this.key, true).toString().replace('http', 'ws');
+    const url = this.server.url(this.key, { includeToken: true }).toString().replace('http', 'ws');
     this._ws = new WebSocket(url);
 
     this._ws.on('message', (buffer: Buffer) => {

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -102,7 +102,7 @@ export class Audio extends Playable {
     // or it might be used for things like `/tree`? The python `url` method seems rarely used directly.
     // For now, mirroring the python seems safest. If `part` is meant to be appended to `this.key`,
     // the logic would need changing.
-    return part ? this.server.url(part, true)?.toString() : undefined;
+    return part ? this.server.url(part, { includeToken: true })?.toString() : undefined;
   }
 
   /** Indicates if the audio item has undergone sonic analysis. */
@@ -168,7 +168,7 @@ export class Audio extends Playable {
 
     const addedAtTimestamp = data.addedAt ? parseInt(data.addedAt, 10) : NaN;
     this.addedAt = isNaN(addedAtTimestamp) ? undefined : new Date(addedAtTimestamp * 1000);
-    this.art = data.art ? this.server.url(data.art, true)?.toString() : undefined;
+    this.art = data.art ? this.server.url(data.art, { includeToken: true })?.toString() : undefined;
     this.artBlurHash = data.artBlurHash;
     const distanceFloat = data.distance ? parseFloat(data.distance) : NaN;
     this.distance = isNaN(distanceFloat) ? undefined : distanceFloat;
@@ -202,7 +202,9 @@ export class Audio extends Playable {
     const ratingKeyInt = data.ratingKey ? parseInt(data.ratingKey, 10) : NaN;
     this.ratingKey = isNaN(ratingKeyInt) ? this.ratingKey : ratingKeyInt.toString();
     this.summary = data.summary;
-    this.thumb = data.thumb ? this.server.url(data.thumb, true)?.toString() : undefined;
+    this.thumb = data.thumb
+      ? this.server.url(data.thumb, { includeToken: true })?.toString()
+      : undefined;
     this.thumbBlurHash = data.thumbBlurHash;
     this.title = data.title ?? this.title;
     this.titleSort = data.titleSort ?? this.title;
@@ -361,14 +363,14 @@ export class Track extends Audio {
   /**
    * Returns the Plex Web URL pointing to the album details page for this track.
    */
-  override getWebURL(base?: string): string {
+  override getWebURL({ base }: { base?: string } = {}): string {
     if (this.parentKey) {
       const params = new URLSearchParams();
       params.append('key', this.parentKey);
-      return this.server._buildWebURL(base, 'details', params);
+      return this.server._buildWebURL({ base, endpoint: 'details', params });
     }
 
-    return super.getWebURL(base);
+    return super.getWebURL({ base });
   }
 
   // metadataDirectory property requires Path module and filesystem access, which is

--- a/src/base/partialPlexObject.ts
+++ b/src/base/partialPlexObject.ts
@@ -206,7 +206,6 @@ export abstract class PartialPlexObject extends PlexObject {
   async history(options: Omit<HistoryOptions, 'ratingKey'> = {}) {
     return this.server.history({ ...options, ratingKey: this.ratingKey });
   }
-  }
 
   async section(): Promise<Section> {
     return (await this.server.library()).sectionByID(this.librarySectionID);

--- a/src/base/partialPlexObject.ts
+++ b/src/base/partialPlexObject.ts
@@ -3,6 +3,7 @@ import { URLSearchParams } from 'url';
 import type { Section } from '../library.js';
 import { SearchResult, searchType } from '../search.js';
 import type { MatchSearchResult } from '../search.types.js';
+import type { HistoryOptions } from '../server.types.js';
 import { getAgentIdentifier, ltrim, type MediaContainer, tagHelper } from '../util.js';
 
 import { PlexObject } from './plexObject.js';
@@ -58,7 +59,7 @@ export abstract class PartialPlexObject extends PlexObject {
    */
   async analyze() {
     const key = `/${ltrim(this.key, ['/'])}/analyze`;
-    await this.server.query(key, 'put');
+    await this.server.query({ path: key, method: 'put' });
   }
 
   /**
@@ -72,7 +73,7 @@ export abstract class PartialPlexObject extends PlexObject {
     }
 
     this.initpath = key;
-    const data = await this.server.query(key);
+    const data = await this.server.query({ path: key });
     const innerData = data.MediaContainer ?? data;
     this._loadFullData(innerData);
   }
@@ -89,11 +90,17 @@ export abstract class PartialPlexObject extends PlexObject {
 
   /**
    * Use match result to update show metadata.
-   * @param searchResult Search result @see {@link PartialPlexObject.matches}
-   * @param auto True uses first match from matches, False allows user to provide the match
-   * @param agent (str): Agent name to be used (imdb, thetvdb, themoviedb, etc.)
+   * @param options Match options.
    */
-  async fixMatch(searchResult?: SearchResult, auto = false, agent = ''): Promise<void> {
+  async fixMatch({
+    searchResult,
+    auto = false,
+    agent = '',
+  }: {
+    searchResult?: SearchResult;
+    auto?: boolean;
+    agent?: string;
+  } = {}): Promise<void> {
     const key = `/library/metadata/${this.ratingKey}/match`;
     if (auto) {
       const autoMatch = await this.matches();
@@ -108,24 +115,20 @@ export abstract class PartialPlexObject extends PlexObject {
 
     const params = new URLSearchParams({ guid: searchResult.guid, name: searchResult.name });
     const url = `${key}?${params.toString()}`;
-    await this.server.query(url, 'put');
+    await this.server.query({ path: url, method: 'put' });
   }
 
   /**
-   *
-   * @param agent Agent name to be used (imdb, thetvdb, themoviedb, etc.)
-   * @param title Title of item to search for
-   * @param year Year of item to search in
-   * @param language Language of item to search in
+   * @param options Match options.
    *
    *  Examples:
    *  1. video.matches()
-   *  2. video.matches(title="something", year=2020)
-   *  3. video.matches(title="something")
-   *  4. video.matches(year=2020)
-   *  5. video.matches(title="something", year="")
-   *  6. video.matches(title="", year=2020)
-   *  7. video.matches(title="", year="")
+   *  2. video.matches({ title: "something", year: "2020" })
+   *  3. video.matches({ title: "something" })
+   *  4. video.matches({ year: "2020" })
+   *  5. video.matches({ title: "something", year: "" })
+   *  6. video.matches({ title: "", year: "2020" })
+   *  7. video.matches({ title: "", year: "" })
    *
    *  1. The default behaviour in Plex Web = no params in plexapi
    *  2. Both title and year specified by user
@@ -137,12 +140,17 @@ export abstract class PartialPlexObject extends PlexObject {
    *
    *  For 2 to 7, the agent and language is automatically filled in
    */
-  async matches(
-    agent?: string,
-    title?: string,
-    year?: string,
-    language?: string,
-  ): Promise<SearchResult[]> {
+  async matches({
+    agent,
+    title,
+    year,
+    language,
+  }: {
+    agent?: string;
+    title?: string;
+    year?: string;
+    language?: string;
+  } = {}): Promise<SearchResult[]> {
     const key = `/library/metadata/${this.ratingKey}/matches`;
     const params = new URLSearchParams({ manual: '1' });
 
@@ -179,26 +187,24 @@ export abstract class PartialPlexObject extends PlexObject {
       }
     }
 
-    const data = await this.server.query<MediaContainer<{ SearchResult: MatchSearchResult[] }>>(
-      `${key}?${params.toString()}`,
-      'get',
-    );
+    const data = await this.server.query<MediaContainer<{ SearchResult: MatchSearchResult[] }>>({
+      path: `${key}?${params.toString()}`,
+    });
     return data.MediaContainer.SearchResult.map(r => new SearchResult(this.server, r));
   }
 
   /** Unmatches metadata match from object. */
   async unmatch() {
     const key = `/library/metadata/${this.ratingKey}/unmatch`;
-    return this.server.query(key, 'put');
+    return this.server.query({ path: key, method: 'put' });
   }
 
   /**
    * Get Play History for a media item.
-   * @param maxresults Only return the specified number of results (optional).
-   * @param mindate Min datetime to return results from.
+   * @param options Filter and paging options.
    */
-  async history(maxresults = 9999999, mindate?: Date) {
-    return this.server.history(maxresults, mindate, this.ratingKey);
+  async history(options: Omit<HistoryOptions, 'ratingKey'> = {}) {
+    return this.server.history({ ...options, ratingKey: this.ratingKey });
   }
 
   async section(): Promise<Section> {
@@ -209,7 +215,7 @@ export abstract class PartialPlexObject extends PlexObject {
    * Delete a media element. This has to be enabled under settings > server > library in plex webui.
    */
   async delete(): Promise<any> {
-    return this.server.query(this.key, 'delete');
+    return this.server.query({ path: this.key, method: 'delete' });
   }
 
   /** Add a collection(s). */
@@ -219,7 +225,7 @@ export abstract class PartialPlexObject extends PlexObject {
 
   /** Remove a collection(s). */
   async removeCollection(collections: string[]) {
-    await this._editTags('collection', collections, undefined, true);
+    await this._editTags('collection', collections, { remove: true });
   }
 
   /** Add a label(s). */
@@ -229,7 +235,7 @@ export abstract class PartialPlexObject extends PlexObject {
 
   /** Remove a label(s). */
   async removeLabel(labels: string[]) {
-    await this._editTags('label', labels, undefined, true);
+    await this._editTags('label', labels, { remove: true });
   }
 
   /** Add a genre(s). */
@@ -239,11 +245,11 @@ export abstract class PartialPlexObject extends PlexObject {
 
   /** Remove a genre(s). */
   async removeGenre(genres: string[]) {
-    await this._editTags('genre', genres, undefined, true);
+    await this._editTags('genre', genres, { remove: true });
   }
 
-  getWebURL(base?: string): string {
-    return this._getWebURL(base);
+  getWebURL({ base }: { base?: string } = {}): string {
+    return this._getWebURL({ base });
   }
 
   /**
@@ -280,8 +286,11 @@ export abstract class PartialPlexObject extends PlexObject {
       Object.entries(changeObj).map(([key, value]) => [key, value.toString()]),
     );
     const params = new URLSearchParams(strObj);
-    const url = this.server.url(`/library/sections/${this.librarySectionID}/all`, true, params);
-    await this.server.query(url.toString(), 'put');
+    const url = this.server.url(`/library/sections/${this.librarySectionID}/all`, {
+      includeToken: true,
+      params,
+    });
+    await this.server.query({ path: url.toString(), method: 'put' });
   }
 
   protected abstract _loadFullData(data: any): void;
@@ -290,23 +299,26 @@ export abstract class PartialPlexObject extends PlexObject {
    * Get the Plex Web URL with the correct parameters.
    * Private method to allow overriding parameters from subclasses.
    */
-  private _getWebURL(base?: string): string {
+  private _getWebURL({ base }: { base?: string } = {}): string {
     const params = new URLSearchParams();
     params.append('key', this.key);
-    return this.server._buildWebURL(base, 'details', params);
+    return this.server._buildWebURL({ base, endpoint: 'details', params });
   }
 
   /**
    * Helper to edit and refresh a tags.
    * @param tag tag name
    * @param items list of tags to add
-   * @param locked lock this field.
-   * @param remove If this is active remove the tags in items.
+   * @param options
    */
-  private async _editTags(tag: string, items: string[], locked = true, remove = false) {
+  private async _editTags(
+    tag: string,
+    items: string[],
+    { locked = true, remove = false }: { locked?: boolean; remove?: boolean } = {},
+  ) {
     const value = (this as any)[tag + 's'];
     const existingCols = value?.filter((x: any) => x && remove).map((x: any) => x.tag) ?? [];
-    const d = tagHelper(tag, [...existingCols, ...items], locked, remove);
+    const d = tagHelper(tag, [...existingCols, ...items], { locked, remove });
     await this.edit(d);
     await this.reload();
   }

--- a/src/base/plexObject.ts
+++ b/src/base/plexObject.ts
@@ -41,7 +41,7 @@ export abstract class PlexObject {
       throw new Error('Cannot reload an object not built from a URL');
     }
 
-    const data = await this.server.query(key);
+    const data = await this.server.query({ path: key });
     const innerData = data.MediaContainer ? data.MediaContainer : data;
     this._loadData(innerData);
   }
@@ -54,7 +54,7 @@ export abstract class PlexObject {
    */
   async refresh() {
     const key = `${this.key}/refresh`;
-    await this.server.query(key, 'put');
+    await this.server.query({ path: key, method: 'put' });
   }
 
   /**

--- a/src/baseFunctionality.ts
+++ b/src/baseFunctionality.ts
@@ -37,7 +37,7 @@ export async function fetchItem(
   cls?: any,
 ): Promise<any> {
   const key = typeof ekey === 'number' ? `/library/metadata/${ekey.toString()}` : ekey;
-  const response = await server.query<MediaContainer<any>>(key);
+  const response = await server.query<MediaContainer<any>>({ path: key });
   const containerKey = cls?.TAG ?? 'Metadata';
   const elems = response.MediaContainer[containerKey] ?? [];
   for (const elem of elems) {
@@ -61,7 +61,7 @@ export async function fetchItems<T = any>(
   Cls?: any,
   parent?: any,
 ): Promise<T[]> {
-  const response = await server.query<MediaContainer<any>>(ekey);
+  const response = await server.query<MediaContainer<any>>({ path: ekey });
   const { MediaContainer } = response;
   const elems = MediaContainer[Cls?.TAG] ?? MediaContainer.Metadata ?? [];
   const items = findItems(elems, options, Cls, server, parent);

--- a/src/client.ts
+++ b/src/client.ts
@@ -139,9 +139,9 @@ export class PlexClient {
    * Build a URL string with proper token argument. Token will be appended to the URL
    * if either includeToken is True or TODO: CONFIG.log.show_secrets is 'true'.
    * @param key
-   * @param includeToken
+   * @param options
    */
-  url(key: string, includeToken = false): URL {
+  url(key: string, { includeToken = false }: { includeToken?: boolean } = {}): URL {
     if (!this._baseurl) {
       throw new Error('PlexClient object missing baseurl.');
     }

--- a/src/media.ts
+++ b/src/media.ts
@@ -125,6 +125,7 @@ export class MediaPart extends PlexObject {
     const key = `/library/parts/${this.id}`;
     const params = new URLSearchParams({ allParts: '1' });
     const streamId = typeof stream === 'number' ? stream : stream.id;
+    params.set('audioStreamID', streamId.toString());
     await this.server.query({ path: `${key}?${params.toString()}`, method: 'put' });
     return this;
   }

--- a/src/media.ts
+++ b/src/media.ts
@@ -126,7 +126,7 @@ export class MediaPart extends PlexObject {
     const params = new URLSearchParams({ allParts: '1' });
     const streamId = typeof stream === 'number' ? stream : stream.id;
     params.set('audioStreamID', streamId.toString());
-    await this.server.query(key + '?' + params.toString(), 'put');
+    await this.server.query({ path: key + '?' + params.toString(), method: 'put' });
     return this;
   }
 
@@ -139,7 +139,7 @@ export class MediaPart extends PlexObject {
     const params = new URLSearchParams({ allParts: '1' });
     const streamId = typeof stream === 'number' ? stream : stream.id;
     params.set('subtitleStreamID', streamId.toString());
-    await this.server.query(key + '?' + params.toString(), 'put');
+    await this.server.query({ path: key + '?' + params.toString(), method: 'put' });
     return this;
   }
 
@@ -418,7 +418,7 @@ export class Optimized extends PlexObject {
    */
   async remove(): Promise<void> {
     const key = `${this.key}/${this.id}`;
-    await this.server.query(key, 'delete');
+    await this.server.query({ path: key, method: 'delete' });
   }
 
   /**
@@ -427,7 +427,7 @@ export class Optimized extends PlexObject {
    */
   async rename(title: string): Promise<void> {
     const key = `${this.key}/${this.id}?Item[title]=${encodeURIComponent(title)}`;
-    await this.server.query(key, 'put');
+    await this.server.query({ path: key, method: 'put' });
   }
 
   /**
@@ -436,7 +436,7 @@ export class Optimized extends PlexObject {
    */
   async reprocess(ratingKey: string | number): Promise<void> {
     const key = `${this.key}/${this.id}/${ratingKey}/enable`;
-    await this.server.query(key, 'put');
+    await this.server.query({ path: key, method: 'put' });
   }
 
   protected _loadData(data: any) {
@@ -525,7 +525,7 @@ abstract class BaseResource extends PlexObject {
     const key = this.key.slice(0, -1);
     const params = new URLSearchParams();
     params.append('url', this.ratingKey);
-    return this.server.query(`${key}?${params.toString()}`, 'put');
+    return this.server.query({ path: `${key}?${params.toString()}`, method: 'put' });
   }
 
   resourceFilepath(): string {
@@ -673,7 +673,7 @@ export class Image extends PlexObject {
     this.alt = data.alt;
     this.type = data.type;
     // Assuming server.url is needed to make this a complete URL
-    this.url = data.url ? this.server.url(data.url, true)?.toString() : undefined;
+    this.url = data.url ? this.server.url(data.url, { includeToken: true })?.toString() : undefined;
   }
 }
 

--- a/src/myplex.ts
+++ b/src/myplex.ts
@@ -64,7 +64,10 @@ export class MyPlexAccount {
    * Pass in the `webLogin` object obtained from `getWebLogin()` and this will poll Plex to see if
    * the user agreed. It returns a connected `MyPlexAccount` or throws an error.
    */
-  static async webLoginCheck(webLogin: WebLogin, timeoutSeconds = 60): Promise<MyPlexAccount> {
+  static async webLoginCheck(
+    webLogin: WebLogin,
+    { timeoutSeconds = 60 }: { timeoutSeconds?: number } = {},
+  ): Promise<MyPlexAccount> {
     const recheckMs = 3000;
     const clientIdentifier = BASE_HEADERS['X-Plex-Client-Identifier'];
     const uri = `https://plex.tv/api/v2/pins/${webLogin.id}`;
@@ -85,7 +88,7 @@ export class MyPlexAccount {
           retryDelay: recheckMs,
         });
         if (tokenResponse.authToken) {
-          const myPlexAccount = new MyPlexAccount(null, '', '', tokenResponse.authToken);
+          const myPlexAccount = new MyPlexAccount({ token: tokenResponse.authToken });
 
           return await myPlexAccount.connect();
         }
@@ -162,23 +165,38 @@ export class MyPlexAccount {
   /** List of devices your allowed to use with this account */
   declare entitlements?: string[];
 
+  public baseUrl: string | null = null;
+  public username?: string;
+  public password?: string;
+  public token?: string;
+  public timeout: number = TIMEOUT;
+  public server?: PlexServer;
+
   /**
-   *
-   * @param username Your MyPlex username
-   * @param password Your MyPlex password
-   * @param token Token used to access this client.
-   * @param session Use your own session object if you want to cache the http responses from PMS
-   * @param timeout timeout in seconds on initial connect to myplex
-   * @param server not often available
+   * @param options Connection + auth options.
    */
-  constructor(
-    public baseUrl: string | null = null,
-    public username?: string,
-    public password?: string,
-    public token?: string,
-    public timeout = TIMEOUT,
-    public server?: PlexServer,
-  ) {
+  constructor({
+    baseUrl = null,
+    username,
+    password,
+    token,
+    timeout = TIMEOUT,
+    server,
+  }: {
+    baseUrl?: string | null;
+    username?: string;
+    password?: string;
+    token?: string;
+    timeout?: number;
+    server?: PlexServer;
+  } = {}) {
+    this.baseUrl = baseUrl;
+    this.username = username;
+    this.password = password;
+    this.token = token;
+    this.timeout = timeout;
+    this.server = server;
+
     if (this.token) {
       Object.defineProperty(this, 'token', {
         enumerable: false,
@@ -210,7 +228,7 @@ export class MyPlexAccount {
       return this;
     }
 
-    const data = await this.query<UserResponse>(MyPlexAccount.key);
+    const data = await this.query<UserResponse>({ url: MyPlexAccount.key });
     this._loadData(data);
     return this;
   }
@@ -229,7 +247,7 @@ export class MyPlexAccount {
   }
 
   async resources(): Promise<MyPlexResource[]> {
-    const data = await this.query<ResourcesResponse[]>(MyPlexResource.key);
+    const data = await this.query<ResourcesResponse[]>({ url: MyPlexResource.key });
     return data.map(device => new MyPlexResource(this, device, this.baseUrl));
   }
 
@@ -254,7 +272,9 @@ export class MyPlexAccount {
    * Returns a list of all :class:`~plexapi.myplex.MyPlexDevice` objects connected to the server.
    */
   async devices(): Promise<MyPlexDevice[]> {
-    const response = await this.query<MediaContainer<{ Device: Device[] }>>(MyPlexDevice.key);
+    const response = await this.query<MediaContainer<{ Device: Device[] }>>({
+      url: MyPlexDevice.key,
+    });
     return response.MediaContainer.Device.map(data => new MyPlexDevice(this.server, data));
   }
 
@@ -264,21 +284,29 @@ export class MyPlexAccount {
    * ElementTree object. Returns None if no data exists in the response.
    * TODO: use headers
    * @param path
-   * @param method
-   * @param headers
-   * @param timeout
+   * @param options
    */
-  async query<T = any>(
-    url: string,
-    method: 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete' = 'get',
-    headers?: any,
-    username?: string,
-    password?: string,
-  ): Promise<T> {
+  async query<T = any>({
+    url,
+    method = 'get',
+    headers,
+    username,
+    password,
+  }: {
+    url: string;
+    method?: 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete';
+    headers?: any;
+    username?: string;
+    password?: string;
+  }): Promise<T> {
     const requestHeaders = this._headers();
     if (username && password) {
       const credentials = Buffer.from(`${username}:${password}`).toString('base64');
       requestHeaders.Authorization = `Basic ${credentials}`;
+    }
+
+    if (headers) {
+      Object.assign(requestHeaders, headers);
     }
 
     if (!url.includes('xml')) {
@@ -310,7 +338,7 @@ export class MyPlexAccount {
    */
   async claimToken(): Promise<string> {
     const url = 'https://plex.tv/api/claim/token.json';
-    const response = await this.query<{ token: string }>(url, 'get', undefined);
+    const response = await this.query<{ token: string }>({ url });
     return response.token;
   }
 
@@ -344,13 +372,12 @@ export class MyPlexAccount {
   }
 
   private async _signin(username?: string, password?: string): Promise<UserResponse> {
-    const data = await this.query<{ user: UserResponse }>(
-      this.SIGNIN,
-      'post',
-      undefined,
+    const data = await this.query<{ user: UserResponse }>({
+      url: this.SIGNIN,
+      method: 'post',
       username,
       password,
-    );
+    });
     return data.user;
   }
 
@@ -590,7 +617,7 @@ export class MyPlexDevice extends PlexObject {
    */
   async delete() {
     const key = `https://plex.tv/devices/${this.id}.xml`;
-    await this.server.query(key, 'delete');
+    await this.server.query({ path: key, method: 'delete' });
   }
 
   protected override _loadData(data: Device): void {

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -112,7 +112,7 @@ export class Playlist extends Playable {
     }
 
     const key = `/playlists/${ratingKey}?${params.toString()}`;
-    await server.query(key, 'put');
+    await server.query({ path: key, method: 'put' });
   }
 
   /** Create a smart playlist. */
@@ -133,7 +133,7 @@ export class Playlist extends Playable {
       smart: '0',
     });
     const key = `/playlists?${params.toString()}`;
-    const data = await server.query(key, 'post');
+    const data = await server.query({ path: key, method: 'post' });
     return new Playlist(server, data.MediaContainer.Metadata[0], key);
   }
 
@@ -156,7 +156,7 @@ export class Playlist extends Playable {
   async _edit(args: { title?: string; summary?: string }) {
     const searchparams = new URLSearchParams(args);
     const key = `${this.key}?${searchparams.toString()}`;
-    await this.server.query(key, 'put');
+    await this.server.query({ path: key, method: 'put' });
   }
 
   override async edit(changeObj: { title?: string; summary?: string }) {
@@ -202,7 +202,7 @@ export class Playlist extends Playable {
     });
 
     const key = `${this.key}/items?${params.toString()}`;
-    await this.server.query(key, 'put');
+    await this.server.query({ path: key, method: 'put' });
   }
 
   /** Remove an item from a playlist. */
@@ -215,13 +215,13 @@ export class Playlist extends Playable {
       const playlistItemId = await this._getPlaylistItemID(item);
       const key = `${this.key}/items/${playlistItemId}`;
 
-      await this.server.query(key, 'delete');
+      await this.server.query({ path: key, method: 'delete' });
     }
   }
 
   /** Delete the playlist. */
   override async delete() {
-    await this.server.query(this.key, 'delete');
+    await this.server.query({ path: this.key, method: 'delete' });
   }
 
   protected _loadData(data: PlaylistResponse) {

--- a/src/playqueue.ts
+++ b/src/playqueue.ts
@@ -84,7 +84,7 @@ export class PlayQueue extends PlexObject {
       params.set(key, value.toString());
     }
     const path = `/playQueues/${playQueueID}?${params.toString()}`;
-    const data = await server.query(path, 'get');
+    const data = await server.query({ path });
     const playQueue = new PlayQueue(server, data.MediaContainer, path);
     return playQueue;
   }
@@ -139,7 +139,7 @@ export class PlayQueue extends PlexObject {
       params.set(key, value.toString());
     }
     const path = `/playQueues?${params.toString()}`;
-    const data = await server.query(path, 'post');
+    const data = await server.query({ path, method: 'post' });
     const playQueue = new PlayQueue(server, data.MediaContainer, path);
     return playQueue;
   }
@@ -160,7 +160,7 @@ export class PlayQueue extends PlexObject {
       params.set(key, value.toString());
     }
     const path = `/playQueues?${params.toString()}`;
-    const data = await server.query(path, 'post');
+    const data = await server.query({ path, method: 'post' });
     const playQueue = new PlayQueue(server, data.MediaContainer, path);
     return playQueue;
   }
@@ -262,7 +262,7 @@ export class PlayQueue extends PlexObject {
       params.set(key, value.toString());
     }
     const path = `/playQueues/${this.playQueueID}?${params.toString()}`;
-    const data = await this.server.query(path, 'put');
+    const data = await this.server.query({ path, method: 'put' });
     this._invalidateCacheAndLoadData(data.MediaContainer);
     return this;
   }
@@ -301,7 +301,7 @@ export class PlayQueue extends PlexObject {
       }
       path += `?${params.toString()}`;
     }
-    const data = await this.server.query(path, 'put');
+    const data = await this.server.query({ path, method: 'put' });
     this._invalidateCacheAndLoadData(data.MediaContainer);
     return this;
   }
@@ -320,7 +320,7 @@ export class PlayQueue extends PlexObject {
     }
 
     const path = `/playQueues/${this.playQueueID}/items/${(queueItem as any).playQueueItemID}`;
-    const data = await this.server.query(path, 'delete');
+    const data = await this.server.query({ path, method: 'delete' });
     this._invalidateCacheAndLoadData(data.MediaContainer);
     return this;
   }
@@ -330,7 +330,7 @@ export class PlayQueue extends PlexObject {
    */
   async clear(): Promise<PlayQueue> {
     const path = `/playQueues/${this.playQueueID}/items`;
-    const data = await this.server.query(path, 'delete');
+    const data = await this.server.query({ path, method: 'delete' });
     this._invalidateCacheAndLoadData(data.MediaContainer);
     return this;
   }
@@ -340,7 +340,7 @@ export class PlayQueue extends PlexObject {
    */
   override async refresh(): Promise<void> {
     const path = `/playQueues/${this.playQueueID}`;
-    const data = await this.server.query(path, 'get');
+    const data = await this.server.query({ path });
     this._invalidateCacheAndLoadData(data.MediaContainer);
   }
 

--- a/src/server.types.ts
+++ b/src/server.types.ts
@@ -126,3 +126,16 @@ export interface ServerConnectionInfo {
   protocolVersion: string;
   protocolCapabilities: string;
 }
+
+export interface HistoryOptions {
+  /** Only return the specified number of results. */
+  maxResults?: number;
+  /** Min datetime to return results from. */
+  minDate?: Date;
+  /** Request history for a specific ratingKey item. */
+  ratingKey?: number | string;
+  /** Request history for a specific account ID. */
+  accountId?: number | string;
+  /** Request history for a specific library section ID. */
+  librarySectionId?: number | string;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -70,7 +70,7 @@ export class Settings extends PlexObject {
     }
 
     const url = `${this.key}?${params.toString()}`;
-    await this.server.query(url, 'put');
+    await this.server.query({ path: url, method: 'put' });
   }
 
   override _loadData(data: SettingResponse[]) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,29 +10,33 @@ export interface MetadataContainer<T extends { Metadata: any }> {
 
 export function rsplit(str: string, sep: string, maxsplit: number): string[] {
   const split = str.split(sep);
-  return maxsplit ? [split.slice(0, -maxsplit).join(sep)].concat(split.slice(-maxsplit)) : split;
+  if (maxsplit) {
+    return [split.slice(0, -maxsplit).join(sep), ...split.slice(-maxsplit)];
+  }
+
+  return split;
 }
 
 /**
  * Return the full agent identifier from a short identifier, name, or confirm full identifier.
- * @param section
- * @param agent
  */
 export async function getAgentIdentifier(section: Section, agent: string) {
-  const agents: any[] = [];
+  const agents: string[] = [];
   for (const ag of await section.agents()) {
     const identifiers = [ag.identifier, ag.shortIdentifier, ag.name];
     if (identifiers.includes(agent)) {
       return ag.identifier;
     }
 
-    agents.concat(identifiers);
+    agents.push(...identifiers);
   }
 
   throw new Error(`Couldnt find "${agent}" in agents list (${agents.join(', ')})`);
 }
 
-/** Simple tag helper for editing a object. */
+/**
+ * Simple tag helper for editing a object.
+ */
 export function tagHelper(
   tag: string,
   items: string[],
@@ -54,14 +58,16 @@ export function tagHelper(
   return data;
 }
 
+/**
+ * Trim characters from the left of the string.
+ */
 export function ltrim(x: string, characters: string[]) {
   let start = 0;
   while (characters.includes(x[start])) {
     start += 1;
   }
 
-  const end = x.length - 1;
-  return x.substr(start, end);
+  return x.slice(start);
 }
 
 export function lowerFirst(str: string) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,33 +10,29 @@ export interface MetadataContainer<T extends { Metadata: any }> {
 
 export function rsplit(str: string, sep: string, maxsplit: number): string[] {
   const split = str.split(sep);
-  if (maxsplit) {
-    return [split.slice(0, -maxsplit).join(sep), ...split.slice(-maxsplit)];
-  }
-
-  return split;
+  return maxsplit ? [split.slice(0, -maxsplit).join(sep)].concat(split.slice(-maxsplit)) : split;
 }
 
 /**
  * Return the full agent identifier from a short identifier, name, or confirm full identifier.
+ * @param section
+ * @param agent
  */
 export async function getAgentIdentifier(section: Section, agent: string) {
-  const agents: string[] = [];
+  const agents: any[] = [];
   for (const ag of await section.agents()) {
     const identifiers = [ag.identifier, ag.shortIdentifier, ag.name];
     if (identifiers.includes(agent)) {
       return ag.identifier;
     }
 
-    agents.push(...identifiers);
+    agents.concat(identifiers);
   }
 
   throw new Error(`Couldnt find "${agent}" in agents list (${agents.join(', ')})`);
 }
 
-/**
- * Simple tag helper for editing a object.
- */
+/** Simple tag helper for editing a object. */
 export function tagHelper(
   tag: string,
   items: string[],
@@ -58,16 +54,14 @@ export function tagHelper(
   return data;
 }
 
-/**
- * Trim characters from the left of the string.
- */
 export function ltrim(x: string, characters: string[]) {
   let start = 0;
   while (characters.includes(x[start])) {
     start += 1;
   }
 
-  return x.slice(start);
+  const end = x.length - 1;
+  return x.substr(start, end);
 }
 
 export function lowerFirst(str: string) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -33,7 +33,11 @@ export async function getAgentIdentifier(section: Section, agent: string) {
 }
 
 /** Simple tag helper for editing a object. */
-export function tagHelper(tag: string, items: string[], locked = true, remove = false) {
+export function tagHelper(
+  tag: string,
+  items: string[],
+  { locked = true, remove = false }: { locked?: boolean; remove?: boolean } = {},
+) {
   const data: Record<string, string | number> = {};
   if (remove) {
     const tagname = `${tag}[].tag.tag-`;

--- a/src/video.ts
+++ b/src/video.ts
@@ -67,12 +67,12 @@ abstract class Video extends Playable {
    */
   get thumbUrl(): URL {
     const thumb = this.thumb ?? (this as any).parentThumb ?? (this as any).granparentThumb;
-    return this.server.url(thumb, true);
+    return this.server.url(thumb, { includeToken: true });
   }
 
   get artUrl(): URL {
     const art = this.art ?? this.grandparentArt;
-    return this.server.url(art, true);
+    return this.server.url(art, { includeToken: true });
   }
 
   /**
@@ -80,7 +80,7 @@ abstract class Video extends Playable {
    */
   async markWatched(): Promise<void> {
     const key = `/:/scrobble?key=${this.ratingKey}&identifier=com.plexapp.plugins.library`;
-    await this.server.query(key);
+    await this.server.query({ path: key });
     await this.reload();
   }
 
@@ -89,18 +89,18 @@ abstract class Video extends Playable {
    */
   async markUnwatched(): Promise<void> {
     const key = `/:/unscrobble?key=${this.ratingKey}&identifier=com.plexapp.plugins.library`;
-    await this.server.query(key);
+    await this.server.query({ path: key });
     await this.reload();
   }
 
   async rate(rate: number): Promise<void> {
     const key = `/:/rate?key=${this.ratingKey}&identifier=com.plexapp.plugins.library&rating=${rate}`;
-    await this.server.query(key);
+    await this.server.query({ path: key });
     await this.reload();
   }
 
   async extras(): Promise<Extra[]> {
-    const data = await this.server.query(this._detailsKey);
+    const data = await this.server.query({ path: this._detailsKey });
     return findItems(
       data.MediaContainer.Metadata[0].Extras?.Metadata,
       undefined,
@@ -134,13 +134,21 @@ abstract class Video extends Playable {
   /**
    * I haven't tested this yet. It may not work.
    */
-  async uploadPoster(url?: string, file?: Uint8Array): Promise<void> {
+  async uploadPoster({
+    url,
+    file,
+  }: {
+    url?: string;
+    file?: Uint8Array;
+  } = {}): Promise<void> {
     if (url) {
       const key = `/library/metadata/${this.ratingKey}/posters?url=${encodeURIComponent(url)}`;
-      await this.server.query(key, 'post');
+      await this.server.query({ path: key, method: 'post' });
     } else if (file) {
       const key = `/library/metadata/${this.ratingKey}/posters`;
-      await this.server.query(key, 'post', {
+      await this.server.query({
+        path: key,
+        method: 'post',
         body: file,
       });
     }

--- a/test/audio-playlist.spec.ts
+++ b/test/audio-playlist.spec.ts
@@ -195,7 +195,7 @@ describe('Audio Playlist Tests', () => {
 
     // Verify deletion by attempting to fetch - should fail or return null
     try {
-      await plex.query(`/playlists/${ratingKey}`);
+      await plex.query({ path: `/playlists/${ratingKey}` });
       // If we get here, deletion failed
       expect.fail('Playlist should have been deleted');
     } catch (error) {

--- a/test/history.spec.ts
+++ b/test/history.spec.ts
@@ -35,7 +35,7 @@ describe('History API Tests', () => {
       const track = tracks[0];
       try {
         const key = `/:/scrobble?key=${track.ratingKey}&identifier=com.plexapp.plugins.library`;
-        await plex.query(key);
+        await plex.query({ path: key });
         await sleep(2000); // Wait for history to be updated
       } catch {
         // Ignore errors - tests will handle empty history gracefully
@@ -44,7 +44,7 @@ describe('History API Tests', () => {
   }, 15000);
 
   it('should return history without filters', async () => {
-    const history = await plex.history(100);
+    const history = await plex.history({ maxResults: 100 });
     expect(Array.isArray(history)).toBe(true);
 
     // Filter out null/undefined items
@@ -59,8 +59,8 @@ describe('History API Tests', () => {
   }, 30000);
 
   it('should filter history by librarySectionId to return only music tracks', async () => {
-    const allHistory = await plex.history(100);
-    const musicHistory = await plex.history(100, undefined, undefined, undefined, musicSectionId);
+    const allHistory = await plex.history({ maxResults: 100 });
+    const musicHistory = await plex.history({ maxResults: 100, librarySectionId: musicSectionId });
 
     // Filter out null/undefined items
     const validAllHistory = allHistory.filter(h => h != null);
@@ -81,7 +81,7 @@ describe('History API Tests', () => {
   }, 30000);
 
   it('should filter history by ratingKey', async () => {
-    const allHistory = await plex.history(10);
+    const allHistory = await plex.history({ maxResults: 10 });
     const validHistory = allHistory.filter(h => h != null);
 
     // If no history, test passes (empty arrays are valid)
@@ -99,7 +99,7 @@ describe('History API Tests', () => {
       return;
     }
 
-    const filteredHistory = await plex.history(100, undefined, ratingKey);
+    const filteredHistory = await plex.history({ maxResults: 100, ratingKey });
     const validFilteredHistory = filteredHistory.filter(h => h != null);
 
     // All items should have the same ratingKey

--- a/test/library.spec.ts
+++ b/test/library.spec.ts
@@ -77,14 +77,14 @@ it('should get movie section plex url', async () => {
   const tab = 'library';
   const library = await plex.library();
   const section = await library.section<MovieSection>('Movies');
-  let url = section.getWebURL(undefined, tab);
+  let url = section.getWebURL({ tab });
   expect(url).toContain('https://app.plex.tv/desktop');
   expect(url).toContain(plex.machineIdentifier);
   expect(url).toContain(`source=${section.key}`);
   expect(url).toContain(`pivot=${tab}`);
   // Test a different base
   const base = 'https://doesnotexist.com/plex';
-  url = section.getWebURL(base);
+  url = section.getWebURL({ base });
   expect(url).toContain(base);
 });
 

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -9,20 +9,30 @@ describe('PlexServer._buildWebURL', () => {
 
   it('should build URL with endpoint and params', () => {
     const params = new URLSearchParams({ key: '/library/metadata/123' });
-    const result = server._buildWebURL('https://app.plex.tv/desktop/', 'details', params);
+    const result = server._buildWebURL({
+      base: 'https://app.plex.tv/desktop/',
+      endpoint: 'details',
+      params,
+    });
     expect(result).toBe(
       'https://app.plex.tv/desktop/#!/server/abc123/details?key=%2Flibrary%2Fmetadata%2F123',
     );
   });
 
   it('should build URL with endpoint but no params', () => {
-    const result = server._buildWebURL('https://app.plex.tv/desktop/', 'playlist');
+    const result = server._buildWebURL({
+      base: 'https://app.plex.tv/desktop/',
+      endpoint: 'playlist',
+    });
     expect(result).toBe('https://app.plex.tv/desktop/#!/server/abc123/playlist');
   });
 
   it('should build URL without endpoint (media URL)', () => {
     const params = new URLSearchParams({ source: 'library' });
-    const result = server._buildWebURL('https://app.plex.tv/desktop/', undefined, params);
+    const result = server._buildWebURL({
+      base: 'https://app.plex.tv/desktop/',
+      params,
+    });
     expect(result).toBe(
       'https://app.plex.tv/desktop/#!/media/abc123/com.plexapp.plugins.library?source=library',
     );

--- a/test/test-client.ts
+++ b/test/test-client.ts
@@ -10,12 +10,12 @@ if (!username && !password && !token) {
 }
 
 export async function createAccount(): Promise<MyPlexAccount> {
-  const account = await new MyPlexAccount(
-    'http://localhost:32400',
+  const account = await new MyPlexAccount({
+    baseUrl: 'http://localhost:32400',
     username,
     password,
     token,
-  ).connect();
+  }).connect();
   return account;
 }
 

--- a/test/util.spec.ts
+++ b/test/util.spec.ts
@@ -22,14 +22,14 @@ describe('tagHelper', () => {
   });
 
   it('should build remove tag object', () => {
-    expect(tagHelper('test', ['a', 'b'], undefined, true)).toEqual({
+    expect(tagHelper('test', ['a', 'b'], { remove: true })).toEqual({
       'test.locked': 1,
       'test[].tag.tag-': 'a,b',
     });
   });
 
   it('should build unlocked tag object', () => {
-    expect(tagHelper('test', ['a', 'b'], false)).toEqual({
+    expect(tagHelper('test', ['a', 'b'], { locked: false })).toEqual({
       'test.locked': 0,
       'test[0].tag.tag': 'a',
       'test[1].tag.tag': 'b',


### PR DESCRIPTION
BREAKING CHANGE: PlexServer.query now takes a single {path, ...} argument; MyPlexAccount.query now takes a single {url, ...} argument; updated all callsites.

# Migration Guide

## Breaking Change: `query()` Method Signature Refactor

### Summary

Both `PlexServer.query()` and `MyPlexAccount.query()` now accept a **single options object** instead of separate positional parameters. This provides a more consistent, extensible API that aligns with modern TypeScript best practices.

### What Changed

#### PlexServer.query()

**Before:**
```typescript
async query<T>(
  path: string,
  options?: {
    method?: 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete';
    headers?: Record<string, string>;
    body?: Uint8Array;
    username?: string;
    password?: string;
  }
): Promise<T>
```

**After:**
```typescript
async query<T>({
  path,
  method = 'get',
  headers,
  body,
  username,
  password,
}: {
  path: string;
  method?: 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete';
  headers?: Record<string, string>;
  body?: Uint8Array;
  username?: string;
  password?: string;
}): Promise<T>
```

#### MyPlexAccount.query()

**Before:**
```typescript
async query<T>(
  url: string,
  options?: {
    method?: 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete';
    headers?: any;
    username?: string;
    password?: string;
  }
): Promise<T>
```

**After:**
```typescript
async query<T>({
  url,
  method = 'get',
  headers,
  username,
  password,
}: {
  url: string;
  method?: 'get' | 'post' | 'put' | 'patch' | 'head' | 'delete';
  headers?: any;
  username?: string;
  password?: string;
}): Promise<T>
```

### Migration Examples

#### Simple GET requests

**Before:**
```typescript
const data = await server.query('/library/sections');
const userData = await account.query('https://plex.tv/api/v2/user');
```

**After:**
```typescript
const data = await server.query({ path: '/library/sections' });
const userData = await account.query({ url: 'https://plex.tv/api/v2/user' });
```

#### POST/PUT/DELETE requests

**Before:**
```typescript
await server.query('/playlists', { method: 'post' });
await server.query('/library/sections/1', { method: 'delete' });
```

**After:**
```typescript
await server.query({ path: '/playlists', method: 'post' });
await server.query({ path: '/library/sections/1', method: 'delete' });
```

#### Requests with custom headers

**Before:**
```typescript
await server.query('/some/endpoint', {
  method: 'put',
  headers: { 'X-Custom': 'value' }
});
```

**After:**
```typescript
await server.query({
  path: '/some/endpoint',
  method: 'put',
  headers: { 'X-Custom': 'value' }
});
```

#### Requests with authentication

**Before:**
```typescript
await server.query('/protected/resource', {
  username: 'user',
  password: 'pass'
});
```

**After:**
```typescript
await server.query({
  path: '/protected/resource',
  username: 'user',
  password: 'pass'
});
```

#### Requests with body data

**Before:**
```typescript
await server.query('/upload', {
  method: 'post',
  body: fileData
});
```

**After:**
```typescript
await server.query({
  path: '/upload',
  method: 'post',
  body: fileData
});
```
