### PR TITLE
feat(library): Add section management helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,8 @@ export * from './playqueue.js';
 export * from './server.js';
 export type { HistoryResult, BandwidthOptions, TranscodeImageOptions } from './server.types.js';
 export * from './serverModels.js';
+export { Setting, Settings } from './settings.js';
+export type { SettingEnumValues, SettingType, SettingValue } from './settings.js';
 export * from './video.js';
 export * from './audio.js';
 export { X_PLEX_IDENTIFIER } from './config.js';

--- a/src/library.ts
+++ b/src/library.ts
@@ -457,6 +457,7 @@ type SearchBuildResult = {
 };
 type SearchParamEntry = [string, string];
 type SearchFilterField = Pick<FilteringField, 'key' | 'type'>;
+type LibrarySearchMetadata = { type?: Libtype } & Record<string, unknown>;
 const FILTER_VALUE_TYPES = [
   'audioLanguage',
   'boolean',
@@ -551,6 +552,19 @@ function classForLibtype(libtype?: Libtype): Class<LibrarySearchItem> | undefine
       return undefined;
     }
   }
+}
+
+function createLibrarySearchItem(
+  server: PlexServer,
+  data: LibrarySearchMetadata,
+  parent?: PlexObject,
+): LibrarySearchItem {
+  const Cls = classForLibtype(data.type);
+  if (!Cls) {
+    throw new Unsupported(`Unsupported library item type: ${String(data.type)}`);
+  }
+
+  return new Cls(server, data, undefined, parent) as LibrarySearchItem;
 }
 
 /**
@@ -934,6 +948,19 @@ export abstract class LibrarySection<SType = SectionType> extends PlexObject {
   async onDeck(): Promise<SType[]> {
     const key = this._buildQueryKey(`/library/sections/${this.key}/onDeck`);
     return fetchItems(this.server, key, undefined, this.SECTION_TYPE, this);
+  }
+
+  /**
+   * Returns items from this library section's Continue Watching hub.
+   */
+  async continueWatching(): Promise<LibrarySearchItem[]> {
+    const key = this._buildQueryKey(`/hubs/sections/${this.key}/continueWatching/items`);
+    const data = await this.server.query<MediaContainer<{ Metadata?: LibrarySearchMetadata[] }>>({
+      path: key,
+    });
+    return (data.MediaContainer.Metadata ?? []).map(item =>
+      createLibrarySearchItem(this.server, item, this),
+    );
   }
 
   /**

--- a/src/library.ts
+++ b/src/library.ts
@@ -50,10 +50,16 @@ import {
   Tag,
   Writer,
 } from './media.js';
-import { Playlist } from './playlist.js';
+import {
+  Playlist,
+  type CreateRegularPlaylistOptions,
+  type CreateSmartPlaylistOptions,
+} from './playlist.js';
 import { type Agent, searchType, SEARCHTYPES } from './search.js';
 import type { SearchResultContainer } from './search.types.js';
 import type { PlexServer } from './server.js';
+import type { HistoryOptions, HistoryResult } from './server.types.js';
+import { Setting, type SettingResponse, type SettingValue } from './settings.js';
 import type { MediaContainer } from './util.js';
 import { Episode, Movie, Season, Show } from './video.js';
 
@@ -401,6 +407,21 @@ export interface SearchArgs {
   filters?: AdvancedSearchFilters;
 }
 
+export interface HubSearchOptions {
+  /** Optionally limit search results to a media type. */
+  mediatype?: keyof typeof SEARCHTYPES;
+  /** Limit the number of results per hub. */
+  limit?: number;
+}
+
+export interface PlaylistSearchOptions {
+  sort?: string;
+  [filter: string]: ItemFilterValue | undefined;
+}
+
+export type SectionAdvancedSettings = Record<string, SettingValue>;
+export type LibrarySectionHistoryOptions = Omit<HistoryOptions, 'librarySectionId'>;
+
 export type SectionType = Movie | Show | Artist | Album | Track;
 export type LibrarySearchItem = SectionType | Season | Episode | Collections;
 type RatingKeyItem = { ratingKey?: number | string };
@@ -699,6 +720,19 @@ export abstract class LibrarySection<SType = SectionType> extends PlexObject {
   }
 
   /**
+   * Returns the advanced preference settings for this library section.
+   */
+  async settings(): Promise<Setting[]> {
+    const key = `/library/sections/${this.key}/prefs`;
+    const data = await this.server.query<MediaContainer<{ Setting?: SettingResponse[] }>>({
+      path: key,
+    });
+    return (data.MediaContainer.Setting ?? []).map(
+      setting => new Setting(this.server, setting, key, this),
+    );
+  }
+
+  /**
    * @param title Title of the item to return.
    * @returns the media item with the specified title.
    */
@@ -810,15 +844,6 @@ export abstract class LibrarySection<SType = SectionType> extends PlexObject {
   }
 
   /**
-   * Get Play History for this library Section for the owner.
-   * @param maxresults (int): Only return the specified number of results (optional).
-   * @param mindate (datetime): Min datetime to return results from.
-   */
-  // async history(maxresults=9999999, mindate?: Date): Promise<any> {
-  //   return this.server.history({ maxResults, minDate, librarySectionId: this.key, accountId: 1 })
-  // }
-
-  /**
    * Scan this section for new media.
    */
   async update(): Promise<void> {
@@ -878,6 +903,52 @@ export abstract class LibrarySection<SType = SectionType> extends PlexObject {
   }
 
   /**
+   * Edit this library section's advanced preference settings.
+   */
+  async editAdvanced(changes: SectionAdvancedSettings): Promise<Section> {
+    const settings = new Map((await this.settings()).map(setting => [setting.id, setting]));
+    const params: Record<string, string> = {};
+
+    for (const [id, value] of Object.entries(changes)) {
+      const setting = settings.get(id);
+      if (!setting) {
+        throw new NotFound(`${String(value)} not found in ${[...settings.keys()].join(', ')}`);
+      }
+
+      setting.set(value);
+      params[`prefs[${setting.id}]`] = setting.toQueryValue();
+    }
+
+    return this.edit(params);
+  }
+
+  /**
+   * Reset this library section's advanced preference settings to their defaults.
+   */
+  async defaultAdvanced(): Promise<Section> {
+    const params: Record<string, string> = {};
+    for (const setting of await this.settings()) {
+      setting.set(setting.default);
+      params[`prefs[${setting.id}]`] = setting.toQueryValue();
+    }
+
+    return this.edit(params);
+  }
+
+  /**
+   * Get watched history for this library section.
+   */
+  async history({ accountId = 1, ...options }: LibrarySectionHistoryOptions = {}): Promise<
+    HistoryResult[]
+  > {
+    return this.server.history({
+      ...options,
+      accountId,
+      librarySectionId: this.key,
+    });
+  }
+
+  /**
    * Returns the managed recommendation hubs for this library section.
    */
   async managedHubs(): Promise<ManagedHub[]> {
@@ -900,6 +971,28 @@ export abstract class LibrarySection<SType = SectionType> extends PlexObject {
   }
 
   /**
+   * Returns section-scoped hub search results.
+   */
+  async hubSearch(query: string, { mediatype, limit }: HubSearchOptions = {}): Promise<Hub[]> {
+    const params: Record<string, string> = {
+      includeCollections: '1',
+      includeExternalMedia: '1',
+      query,
+      sectionId: this.key.toString(),
+    };
+    if (limit !== undefined) {
+      params.limit = limit.toString();
+    }
+
+    if (mediatype !== undefined) {
+      params.section = SEARCHTYPES[mediatype].toString();
+    }
+
+    const key = `/hubs/search?${new URLSearchParams(params).toString()}`;
+    return fetchItems<Hub>(this.server, key, undefined, Hub, this);
+  }
+
+  /**
    * Returns the current library section timeline status.
    */
   async timeline(): Promise<LibraryTimeline> {
@@ -911,9 +1004,52 @@ export abstract class LibrarySection<SType = SectionType> extends PlexObject {
   /**
    * Returns a list of playlists from this library section.
    */
-  async playlists(): Promise<Playlist[]> {
-    const key = `/playlists?type=15&playlistType=${this.CONTENT_TYPE}&sectionID=${this.key}`;
-    return fetchItems<Playlist>(this.server, key, undefined, Playlist, this);
+  async playlists(args: PlaylistSearchOptions = {}): Promise<Playlist[]> {
+    const { sort, ...filterOptions } = args;
+    const filters: Record<string, ItemFilterValue> = {};
+    for (const [key, value] of Object.entries(filterOptions)) {
+      if (value !== undefined) {
+        filters[key] = value;
+      }
+    }
+
+    const params = new URLSearchParams({
+      type: '15',
+      playlistType: this.CONTENT_TYPE,
+      sectionID: this.key,
+    });
+    if (sort !== undefined) {
+      params.set('sort', sort);
+    }
+
+    const key = `/playlists?${params.toString()}`;
+    return fetchItems<Playlist>(this.server, key, filters, Playlist, this);
+  }
+
+  /**
+   * Create a regular or smart playlist scoped to this library section.
+   */
+  async createPlaylist(
+    title: string,
+    options: CreateRegularPlaylistOptions | Omit<CreateSmartPlaylistOptions, 'section'>,
+  ): Promise<Playlist> {
+    if (options.smart) {
+      return Playlist.create(this.server, title, { ...options, section: this });
+    }
+
+    return Playlist.create(this.server, title, options);
+  }
+
+  /**
+   * Returns the playlist with the exact title.
+   */
+  async playlist(title: string): Promise<Playlist> {
+    const [playlist] = await this.playlists({ title, title__iexact: title });
+    if (!playlist) {
+      throw new NotFound(`Unable to find playlist with title "${title}".`);
+    }
+
+    return playlist;
   }
 
   async collections(
@@ -927,6 +1063,28 @@ export abstract class LibrarySection<SType = SectionType> extends PlexObject {
       collection.VIDEO_TYPE = this.SECTION_TYPE;
     });
     return collections;
+  }
+
+  /**
+   * Create a regular collection in this library section.
+   */
+  async createCollection<T extends RatingKeyItem>(
+    title: string,
+    items: T[],
+  ): Promise<Collections<T>> {
+    return Collections.create(this.server, title, this as unknown as LibrarySection<T>, items);
+  }
+
+  /**
+   * Returns the collection with the exact title.
+   */
+  async collection(title: string): Promise<Collections<SType>> {
+    const [collection] = await this.collections({ title, title__iexact: title });
+    if (!collection) {
+      throw new NotFound(`Unable to find collection with title "${title}".`);
+    }
+
+    return collection;
   }
 
   /**
@@ -2211,7 +2369,13 @@ export class Collections<
       throw new BadRequest('At least one item is required to create a collection.');
     }
 
-    const ratingKeys = items.map(item => item.ratingKey).join(',');
+    const ratingKeys = items.map(item => {
+      if (!item.ratingKey) {
+        throw new BadRequest(`Cannot add item without a ratingKey to collection "${title}".`);
+      }
+
+      return item.ratingKey;
+    });
     const uri = `${server._uriRoot()}/library/metadata/${ratingKeys}`;
     const sectionType = searchType(section.type);
     const params = new URLSearchParams({

--- a/src/library.ts
+++ b/src/library.ts
@@ -912,7 +912,7 @@ export abstract class LibrarySection<SType = SectionType> extends PlexObject {
     for (const [id, value] of Object.entries(changes)) {
       const setting = settings.get(id);
       if (!setting) {
-        throw new NotFound(`${String(value)} not found in ${[...settings.keys()].join(', ')}`);
+        throw new NotFound(`${id} not found in ${[...settings.keys()].join(', ')}`);
       }
 
       setting.set(value);

--- a/src/playlist.ts
+++ b/src/playlist.ts
@@ -4,7 +4,7 @@ import { Album, Artist, Track } from './audio.js';
 import { Playable } from './base/playable.js';
 import { fetchItems } from './baseFunctionality.js';
 import { BadRequest, NotFound } from './exceptions.js';
-import type { Section, SectionType } from './library.js';
+import type { LibrarySection, SectionType } from './library.js';
 import type { PlaylistResponse } from './playlist.types.js';
 import { searchType } from './search.js';
 import type { PlexServer } from './server.js';
@@ -36,18 +36,18 @@ function contentClass(data: any) {
   }
 }
 
-interface CreateRegularPlaylistOptions {
+export interface CreateRegularPlaylistOptions {
   /** True to create a smart playlist */
   smart?: false;
   /** Regular playlists only */
-  items?: SectionType[];
+  items: SectionType[];
 }
 
-interface CreateSmartPlaylistOptions {
+export interface CreateSmartPlaylistOptions {
   /** True to create a smart playlist */
   smart: true;
   /** Smart playlists only, the library section to create the playlist in. */
-  section?: Section;
+  section?: LibrarySection<unknown>;
   /** Smart playlists only, limit the number of items in the playlist. */
   limit?: number;
   /**
@@ -60,10 +60,10 @@ interface CreateSmartPlaylistOptions {
    * Smart playlists only, a dictionary of advanced filters.
    * See {@link Section.search}  for more info.
    */
-  filters?: Record<string, any>;
+  filters?: Record<string, boolean | number | string>;
 }
 
-type CreatePlaylistOptions = CreateRegularPlaylistOptions | CreateSmartPlaylistOptions;
+export type CreatePlaylistOptions = CreateRegularPlaylistOptions | CreateSmartPlaylistOptions;
 type PlaylistContent = Episode | Movie | Track | Album | Artist;
 
 export interface UpdatePlaylistOptions {
@@ -173,7 +173,13 @@ export class Playlist extends Playable {
     }
 
     const { listType } = items[0];
-    const ratingKeys = items ? items.map(x => x.ratingKey) : [];
+    const ratingKeys = items.map(item => {
+      if (!item.ratingKey) {
+        throw new BadRequest(`Cannot add item without a ratingKey to playlist "${title}".`);
+      }
+
+      return item.ratingKey;
+    });
     const uri = `${server._uriRoot()}/library/metadata/${ratingKeys.join(',')}`;
     const params = new URLSearchParams({
       uri,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,39 +1,24 @@
 import { URLSearchParams } from 'node:url';
 
 import { PlexObject } from './base/plexObject.js';
-import { NotFound } from './exceptions.js';
+import { BadRequest, NotFound } from './exceptions.js';
 import { lowerFirst } from './util.js';
+
+export type SettingType = 'bool' | 'double' | 'enum' | 'int' | 'text';
+export type SettingValue = boolean | number | string;
+export type SettingEnumValues = Record<string, string> | string[];
 
 export interface SettingResponse {
   id: string;
   label: string;
   summary: string;
-  type: Type;
-  default: boolean | number | string;
-  value: boolean | number | string;
-  hidden: boolean;
-  advanced: boolean;
-  group: SettingsGroup;
-  // enumValues?: string;
-}
-
-enum SettingsGroup {
-  Butler = 'butler',
-  Channels = 'channels',
-  Dlna = 'dlna',
-  Empty = '',
-  Extras = 'extras',
-  General = 'general',
-  Library = 'library',
-  Network = 'network',
-  Transcoder = 'transcoder',
-}
-
-enum Type {
-  Bool = 'bool',
-  Double = 'double',
-  Int = 'int',
-  Text = 'text',
+  type: SettingType;
+  default: SettingValue;
+  value: SettingValue;
+  hidden: boolean | number | string;
+  advanced: boolean | number | string;
+  group: string;
+  enumValues?: string;
 }
 
 export class Settings extends PlexObject {
@@ -100,11 +85,11 @@ export class Setting extends PlexObject {
   /** Long description of what this setting is. */
   declare summary: string;
   /** Setting type (text, int, double, bool). */
-  declare type: string;
+  declare type: SettingType;
   /** Default value for this setting. */
-  declare default: string | boolean | number;
+  declare default: SettingValue;
   /** Current value for this setting. */
-  declare value: string | boolean | number;
+  declare value: SettingValue;
   /** True if this is a hidden setting. */
   declare hidden: boolean;
   /** True if this is an advanced setting. */
@@ -112,34 +97,92 @@ export class Setting extends PlexObject {
   /** Group name this setting is categorized as. */
   declare group: string;
   /** List or dictionary of valis values for this setting. */
-  declare enumValues: any[] | any;
-  _setValue: string | boolean | number | null = null;
+  declare enumValues?: SettingEnumValues;
+  _setValue: SettingValue | null = null;
 
   /**
    * Set a new value for this setitng. NOTE: You must call {@link Settings.save} before
    * any changes to setting values are persisted to the PlexServer.
    */
-  set(value: string | boolean | number): void {
-    if (typeof value !== typeof this.value) {
-      throw new TypeError('Invalid type');
+  set(value: SettingValue): void {
+    const castValue = this._cast(value);
+    if (typeof castValue !== typeof this.value) {
+      throw new BadRequest(`Invalid value for ${this.id}: expected ${this.type}.`);
     }
 
-    this._setValue = value;
+    if (this.enumValues) {
+      const allowedValues = Array.isArray(this.enumValues)
+        ? this.enumValues
+        : Object.keys(this.enumValues);
+      const allowedValue = this.toQueryValue(castValue);
+      if (!allowedValues.includes(allowedValue)) {
+        throw new BadRequest(`Invalid value for ${this.id}: ${castValue} not in ${allowedValues}`);
+      }
+    }
+
+    this._setValue = castValue;
+  }
+
+  toQueryValue(value: SettingValue = this._setValue ?? this.value): string {
+    if (this.type === 'bool') {
+      return value ? '1' : '0';
+    }
+
+    return value.toString();
   }
 
   override _loadData(data: SettingResponse) {
-    // this._setValue = None
+    this._setValue = null;
     this.id = data.id;
     this.label = data.label;
     this.summary = data.summary;
     this.type = data.type;
-    this.default = data.default;
-    this.value = data.value;
-    this.hidden = data.hidden;
-    this.advanced = data.advanced;
+    this.default = this._cast(data.default);
+    this.value = this._cast(data.value);
+    this.hidden = parsePlexBoolean(data.hidden);
+    this.advanced = parsePlexBoolean(data.advanced);
     this.group = data.group;
-    // this.enumValues = this._getEnumValues(data);
+    this.enumValues = this._getEnumValues(data.enumValues);
   }
+
+  private _cast(value: SettingValue): SettingValue {
+    switch (this.type) {
+      case 'bool': {
+        return parsePlexBoolean(value);
+      }
+
+      case 'double':
+      case 'int': {
+        const numericValue = Number(value);
+        if (Number.isNaN(numericValue)) {
+          throw new BadRequest(`Invalid value for ${this.id}: expected ${this.type}.`);
+        }
+
+        return numericValue;
+      }
+
+      case 'enum':
+      case 'text': {
+        return value.toString();
+      }
+    }
+  }
+
+  private _getEnumValues(enumValues?: string): SettingEnumValues | undefined {
+    if (!enumValues) {
+      return undefined;
+    }
+
+    if (enumValues.includes(':')) {
+      return Object.fromEntries(enumValues.split('|').map(value => value.split(':', 2)));
+    }
+
+    return enumValues.split('|');
+  }
+}
+
+function parsePlexBoolean(value: unknown): boolean {
+  return value === true || value === 1 || value === '1' || value === 'true';
 }
 
 export class Preferences extends Setting {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -165,6 +165,11 @@ export class Setting extends PlexObject {
       case 'text': {
         return value.toString();
       }
+
+      default: {
+        const settingType = this.type as string;
+        throw new BadRequest(`Unknown setting type "${settingType}" for ${this.id}.`);
+      }
     }
   }
 

--- a/test/library-helpers.spec.ts
+++ b/test/library-helpers.spec.ts
@@ -5,6 +5,7 @@ import {
   Movie,
   MovieSection,
   NotFound,
+  Setting,
   ShowSection,
   type EditableLibraryItem,
   type PlexServer,
@@ -122,13 +123,83 @@ const genreChoices = [
   { fastKey: '/library/sections/1/all?genre=2&type=1', key: '2', title: 'Comedy', type: 'genre' },
 ];
 
+const collectionData = {
+  childCount: 1,
+  key: '/library/metadata/99',
+  ratingKey: 99,
+  smart: false,
+  title: 'Test Collection',
+  type: 'collection',
+};
+
+const playlistData = {
+  addedAt: 1,
+  composite: '/playlists/88/composite',
+  guid: 'playlist://88',
+  key: '/playlists/88/items',
+  leafCount: 1,
+  playlistType: 'video',
+  ratingKey: '88',
+  smart: false,
+  summary: '',
+  title: 'Test Playlist',
+  type: 'playlist',
+  updatedAt: 1,
+};
+
 function createMovieSection() {
+  const createCollectionParams = new URLSearchParams({
+    title: 'Test Collection',
+    type: '1',
+    sectionId: '1',
+    uri: 'server://machine/library/metadata/10',
+  });
   const responses = new Map<string, unknown>([
     [
       '/library/sections/1/all?includeMeta=1&includeAdvanced=1&X-Plex-Container-Start=0&X-Plex-Container-Size=0',
       { MediaContainer: { Meta: [filterMeta] } },
     ],
     ['/library/sections/1/genre', { MediaContainer: { Directory: genreChoices } }],
+    [
+      '/library/sections/1/prefs',
+      {
+        MediaContainer: {
+          Setting: [
+            {
+              advanced: '1',
+              default: '0',
+              enumValues: '0:Disabled|1:Enabled',
+              group: 'library',
+              hidden: '0',
+              id: 'includeInGlobal',
+              label: 'Include in dashboard',
+              summary: 'Show this library on the dashboard.',
+              type: 'bool',
+              value: '1',
+            },
+          ],
+        },
+      },
+    ],
+    [
+      '/hubs/search?includeCollections=1&includeExternalMedia=1&query=bunny&sectionId=1&limit=2&section=1',
+      {
+        MediaContainer: {
+          Hub: [
+            {
+              context: 'hub.search',
+              hubIdentifier: 'movie',
+              key: '/hubs/search',
+              more: false,
+              size: 1,
+              style: 'shelf',
+              title: 'Movies',
+              type: 'movie',
+            },
+          ],
+        },
+      },
+    ],
     [
       '/hubs/sections/1/continueWatching/items?includeGuids=1',
       {
@@ -145,12 +216,39 @@ function createMovieSection() {
         },
       },
     ],
+    [
+      `/library/collections?${createCollectionParams.toString()}`,
+      { MediaContainer: { Metadata: [collectionData] } },
+    ],
+    [
+      '/library/sections/1/all?includeGuids=1&title=Test+Collection&type=18',
+      { MediaContainer: { Directory: [collectionData] } },
+    ],
+    [
+      '/playlists?uri=server%3A%2F%2Fmachine%2Flibrary%2Fmetadata%2F10&type=video&title=Test+Playlist&smart=0',
+      { MediaContainer: { Metadata: [playlistData] } },
+    ],
+    [
+      '/playlists?type=15&playlistType=video&sectionID=1',
+      { MediaContainer: { Playlist: [playlistData] } },
+    ],
   ]);
   const query = vi.fn(({ path }: { path: string }) =>
     Promise.resolve(responses.get(path) ?? { MediaContainer: { Metadata: [] } }),
   );
-  const section = new MovieSection({ query } as unknown as PlexServer, movieSectionData);
-  return { query, section };
+  const history = vi.fn(async () => []);
+  const sections: MovieSection[] = [];
+  const server = {
+    history,
+    _uriRoot: vi.fn(() => 'server://machine'),
+    query,
+    library: vi.fn(async () => ({
+      sections: vi.fn(async () => sections),
+    })),
+  } as unknown as PlexServer;
+  const section = new MovieSection(server, movieSectionData);
+  sections.push(section);
+  return { history, query, section };
 }
 
 function lastQueryPath(query: ReturnType<typeof vi.fn>): string {
@@ -168,6 +266,21 @@ function lastQueryEntries(query: ReturnType<typeof vi.fn>): Array<[string, strin
 }
 
 describe('LibrarySection edit helpers', () => {
+  it('returns typed advanced settings for the section', async () => {
+    const { query, section } = createMovieSection();
+
+    const settings = await section.settings();
+
+    expect(settings[0]).toBeInstanceOf(Setting);
+    expect(settings[0].id).toBe('includeInGlobal');
+    expect(settings[0].value).toBe(true);
+    expect(settings[0].default).toBe(false);
+    expect(settings[0].advanced).toBe(true);
+    expect(settings[0].hidden).toBe(false);
+    expect(settings[0].enumValues).toEqual({ '0': 'Disabled', '1': 'Enabled' });
+    expect(query).toHaveBeenCalledWith({ path: '/library/sections/1/prefs' });
+  });
+
   it('returns typed continue watching items for the section hub', async () => {
     const { query, section } = createMovieSection();
 
@@ -177,6 +290,107 @@ describe('LibrarySection edit helpers', () => {
     expect(items[0].title).toBe('Continue Movie');
     expect(query).toHaveBeenCalledWith({
       path: '/hubs/sections/1/continueWatching/items?includeGuids=1',
+    });
+  });
+
+  it('searches hubs scoped to the section', async () => {
+    const { query, section } = createMovieSection();
+
+    const hubs = await section.hubSearch('bunny', { limit: 2, mediatype: 'movie' });
+
+    expect(hubs[0].title).toBe('Movies');
+    expect(hubs[0].type).toBe('movie');
+    expect(query).toHaveBeenCalledWith({
+      path: '/hubs/search?includeCollections=1&includeExternalMedia=1&query=bunny&sectionId=1&limit=2&section=1',
+    });
+  });
+
+  it('fetches watched history scoped to the section', async () => {
+    const { history, section } = createMovieSection();
+
+    await section.history({ maxResults: 2, ratingKey: 10 });
+
+    expect(history).toHaveBeenCalledWith({
+      accountId: 1,
+      librarySectionId: '1',
+      maxResults: 2,
+      ratingKey: 10,
+    });
+  });
+
+  it('creates a typed collection in the section', async () => {
+    const { query, section } = createMovieSection();
+
+    const collection = await section.createCollection('Test Collection', [{ ratingKey: 10 }]);
+
+    expect(collection.title).toBe('Test Collection');
+    expect(collection.ratingKey).toBe(99);
+    expect(query).toHaveBeenCalledWith({
+      path: '/library/collections?title=Test+Collection&type=1&sectionId=1&uri=server%3A%2F%2Fmachine%2Flibrary%2Fmetadata%2F10',
+      method: 'post',
+    });
+  });
+
+  it('finds a typed collection by exact title', async () => {
+    const { section } = createMovieSection();
+
+    const collection = await section.collection('Test Collection');
+
+    expect(collection.title).toBe('Test Collection');
+    expect(collection.ratingKey).toBe(99);
+  });
+
+  it('creates a typed playlist in the section', async () => {
+    const { query, section } = createMovieSection();
+
+    const playlist = await section.createPlaylist('Test Playlist', {
+      items: [{ listType: 'video', ratingKey: 10 } as unknown as Movie],
+    });
+
+    expect(playlist.title).toBe('Test Playlist');
+    expect(playlist.ratingKey).toBe('88');
+    expect(query).toHaveBeenCalledWith({
+      path: '/playlists?uri=server%3A%2F%2Fmachine%2Flibrary%2Fmetadata%2F10&type=video&title=Test+Playlist&smart=0',
+      method: 'post',
+    });
+  });
+
+  it('finds a typed playlist by exact title', async () => {
+    const { section } = createMovieSection();
+
+    const playlist = await section.playlist('Test Playlist');
+
+    expect(playlist.title).toBe('Test Playlist');
+    expect(playlist.ratingKey).toBe('88');
+  });
+
+  it('edits advanced section settings with validated values', async () => {
+    const { query, section } = createMovieSection();
+
+    const editedSection = await section.editAdvanced({ includeInGlobal: true });
+
+    expect(editedSection).toBe(section);
+    expect(query).toHaveBeenCalledWith({
+      path: '/library/sections/1?prefs%5BincludeInGlobal%5D=1',
+      method: 'put',
+    });
+  });
+
+  it('rejects unknown advanced section settings', async () => {
+    const { section } = createMovieSection();
+
+    await expect(section.editAdvanced({ missingSetting: true })).rejects.toThrow(NotFound);
+  });
+
+  it('resets advanced section settings to their defaults', async () => {
+    const { query, section } = createMovieSection();
+
+    const editedSection = await section.defaultAdvanced();
+
+    expect(editedSection).toBe(section);
+    expect(query).toHaveBeenCalledWith({
+      path: '/library/sections/1?prefs%5BincludeInGlobal%5D=0',
+      method: 'put',
     });
   });
 

--- a/test/library-helpers.spec.ts
+++ b/test/library-helpers.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   BadRequest,
+  Movie,
   MovieSection,
   NotFound,
   ShowSection,
@@ -128,6 +129,22 @@ function createMovieSection() {
       { MediaContainer: { Meta: [filterMeta] } },
     ],
     ['/library/sections/1/genre', { MediaContainer: { Directory: genreChoices } }],
+    [
+      '/hubs/sections/1/continueWatching/items?includeGuids=1',
+      {
+        MediaContainer: {
+          Metadata: [
+            {
+              addedAt: 1,
+              key: '/library/metadata/10',
+              ratingKey: 10,
+              title: 'Continue Movie',
+              type: 'movie',
+            },
+          ],
+        },
+      },
+    ],
   ]);
   const query = vi.fn(({ path }: { path: string }) =>
     Promise.resolve(responses.get(path) ?? { MediaContainer: { Metadata: [] } }),
@@ -151,6 +168,18 @@ function lastQueryEntries(query: ReturnType<typeof vi.fn>): Array<[string, strin
 }
 
 describe('LibrarySection edit helpers', () => {
+  it('returns typed continue watching items for the section hub', async () => {
+    const { query, section } = createMovieSection();
+
+    const items = await section.continueWatching();
+
+    expect(items[0]).toBeInstanceOf(Movie);
+    expect(items[0].title).toBe('Continue Movie');
+    expect(query).toHaveBeenCalledWith({
+      path: '/hubs/sections/1/continueWatching/items?includeGuids=1',
+    });
+  });
+
   it('accepts child items that belong to the section through their parent', async () => {
     const query = vi.fn().mockResolvedValue({
       MediaContainer: {

--- a/test/library-helpers.spec.ts
+++ b/test/library-helpers.spec.ts
@@ -379,7 +379,33 @@ describe('LibrarySection edit helpers', () => {
   it('rejects unknown advanced section settings', async () => {
     const { section } = createMovieSection();
 
-    await expect(section.editAdvanced({ missingSetting: true })).rejects.toThrow(NotFound);
+    await expect(section.editAdvanced({ missingSetting: true })).rejects.toThrow(
+      'missingSetting not found',
+    );
+  });
+
+  it('rejects unknown setting types', async () => {
+    const { section } = createMovieSection();
+
+    expect(
+      () =>
+        new Setting(
+          section.server,
+          {
+            advanced: '0',
+            default: 'value',
+            group: 'library',
+            hidden: '0',
+            id: 'unexpectedSetting',
+            label: 'Unexpected',
+            summary: 'Unexpected setting type.',
+            type: 'mystery',
+            value: 'value',
+          },
+          '/library/sections/1/prefs',
+          section,
+        ),
+    ).toThrow(BadRequest);
   });
 
   it('resets advanced section settings to their defaults', async () => {


### PR DESCRIPTION
Adds the missing section-level helpers for Continue Watching, settings, advanced preference edits, watched history, hub search, collections, and playlists. These mostly mirror the python-plexapi surface, but the TypeScript API is stricter where it can be: playlist creation has to choose regular items or smart options, settings cast and validate values before writing prefs, and collection/playlist creation rejects missing rating keys before building Plex URLs.

Also tightens and exports the shared Setting and playlist creation types so callers do not have to fall back to raw payload shapes.