### PR TITLE
feat(library): Add photo library support

### DIFF
--- a/scripts/bootstraptest.ts
+++ b/scripts/bootstraptest.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { copyFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 
@@ -87,6 +88,11 @@ const yarg = yargs(hideBin(process.argv))
     type: 'boolean',
     desc: 'Create Audio section',
     default: true,
+  })
+  .option('create-photos', {
+    type: 'boolean',
+    desc: 'Create Photos section',
+    default: false,
   });
 
 const dockerCmd = ({
@@ -273,6 +279,12 @@ async function setupAudio(audioPath: string): Promise<number> {
   }
 
   return totalTracks;
+}
+
+async function setupPhotos(photoPath: string): Promise<number> {
+  await makeDirectory(photoPath);
+  await copyFile(join(__dirname, '..', 'test/data/cute_cat.jpg'), join(photoPath, 'Cute Cat.jpg'));
+  return 1;
 }
 
 async function main() {
@@ -496,6 +508,26 @@ async function main() {
       scanner: 'Plex Music',
       language: 'en-US',
       expectedMediaCount: numTracks,
+    });
+  }
+
+  if (argv['create-photos']) {
+    const photosPath = join(mediaPath, 'Photos');
+    const setupPhotosProgress = ora(`Setup photo files`).start();
+    const numPhotos = await setupPhotos(photosPath);
+    setupPhotosProgress.succeed();
+    sections.push({
+      name: 'Photos',
+      type: 'photo',
+      location: '/data/Photos',
+      agent: 'com.plexapp.agents.none',
+      scanner: 'Plex Photo Scanner',
+      language: 'en-US',
+      expectedMediaCount: numPhotos,
+      prefs: {
+        'prefs[enableAutoPhotoTags]': '0',
+        'prefs[enableBIFGeneration]': '0',
+      },
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ export * from './media.js';
 export * from './myplex.js';
 export * from './playlist.js';
 export * from './playqueue.js';
+export * from './photo.js';
+export type { PhotoalbumData, PhotoData, PhotoMediaData, PhotoPartData } from './photo.types.js';
 export * from './server.js';
 export type { HistoryResult, BandwidthOptions, TranscodeImageOptions } from './server.types.js';
 export * from './serverModels.js';

--- a/src/library.ts
+++ b/src/library.ts
@@ -50,6 +50,7 @@ import {
   Tag,
   Writer,
 } from './media.js';
+import { Photo, Photoalbum } from './photo.js';
 import {
   Playlist,
   type CreateRegularPlaylistOptions,
@@ -63,7 +64,7 @@ import { Setting, type SettingResponse, type SettingValue } from './settings.js'
 import type { MediaContainer } from './util.js';
 import { Episode, Movie, Season, Show } from './video.js';
 
-export type Section = MovieSection | ShowSection | MusicSection;
+export type Section = MovieSection | ShowSection | MusicSection | PhotoSection;
 
 export class Library {
   static key = '/library';
@@ -95,7 +96,7 @@ export class Library {
     }
 
     for (const elem of elems.MediaContainer.Directory) {
-      for (const cls of [MovieSection, ShowSection, MusicSection]) {
+      for (const cls of [MovieSection, ShowSection, MusicSection, PhotoSection]) {
         if (cls.TYPE === elem.type) {
           const instance = new cls(this.server, elem, key);
           sections.push(instance);
@@ -422,8 +423,8 @@ export interface PlaylistSearchOptions {
 export type SectionAdvancedSettings = Record<string, SettingValue>;
 export type LibrarySectionHistoryOptions = Omit<HistoryOptions, 'librarySectionId'>;
 
-export type SectionType = Movie | Show | Artist | Album | Track;
-export type LibrarySearchItem = SectionType | Season | Episode | Collections;
+export type SectionType = Movie | Show | Artist | Album | Track | Photoalbum;
+export type LibrarySearchItem = SectionType | Season | Episode | Photo | Collections;
 type RatingKeyItem = { ratingKey?: number | string };
 type SearchTagValue = { id: number | string; tag?: string } | { id?: number | string; tag: string };
 export type SearchFilterPrimitive =
@@ -471,7 +472,11 @@ export type SearchClassForLibtype<T extends Libtype> = T extends 'movie'
             ? Album
             : T extends 'track'
               ? Track
-              : SectionType;
+              : T extends 'photoalbum'
+                ? Photoalbum
+                : T extends 'photo'
+                  ? Photo
+                  : SectionType;
 type SearchBuildResult = {
   key: string;
   localFilters: Record<string, ItemFilterValue>;
@@ -563,6 +568,14 @@ function classForLibtype(libtype?: Libtype): Class<LibrarySearchItem> | undefine
 
     case 'track': {
       return Track;
+    }
+
+    case 'photoalbum': {
+      return Photoalbum;
+    }
+
+    case 'photo': {
+      return Photo;
     }
 
     case 'collection': {
@@ -2061,6 +2074,55 @@ export class MusicSection extends LibrarySection<Track> {
       endID,
     });
     return fetchItems<Track>(this.server, key, undefined, Track, this);
+  }
+}
+
+export class PhotoSection extends LibrarySection<Photoalbum> {
+  static override TYPE = 'photo';
+  static override ALLOWED_FILTERS = ['year', 'label', 'addedAt'];
+  static override ALLOWED_SORT = ['addedAt', 'titleSort', 'viewUpdatedAt'];
+  static override TAG = 'Directory';
+  METADATA_TYPE = 'photo';
+  override CONTENT_TYPE = 'photo';
+  override readonly SECTION_TYPE = Photoalbum;
+
+  /** Returns photo albums in this section. */
+  override async all(args: Partial<SearchArgs> | string = {}): Promise<Photoalbum[]> {
+    const searchArgs = typeof args === 'string' ? { sort: args } : args;
+    return this.search({ ...searchArgs, libtype: 'photoalbum' }, Photoalbum);
+  }
+
+  /** Photo libraries do not support collections. */
+  override async collections(): Promise<Array<Collections<Photoalbum>>> {
+    throw new Unsupported('Collections are not available for a Photo library.');
+  }
+
+  /** Search for a photo album. */
+  async searchAlbums(args: Partial<SearchArgs> = {}): Promise<Photoalbum[]> {
+    return this.search({ ...args, libtype: 'photoalbum' }, Photoalbum);
+  }
+
+  /** Search for a photo. */
+  async searchPhotos(args: Partial<SearchArgs> = {}): Promise<Photo[]> {
+    return this.search({ ...args, libtype: 'photo' }, Photo);
+  }
+
+  /** Returns recently added photo albums from this library section. */
+  async recentlyAddedAlbums(maxResults = 50): Promise<Photoalbum[]> {
+    return this.search(
+      { maxresults: maxResults, sort: 'addedAt:desc', libtype: 'photoalbum' },
+      Photoalbum,
+    );
+  }
+
+  /** Returns recently added photos from this library section. */
+  async recentlyAddedPhotos(maxResults = 50): Promise<Photo[]> {
+    return this.search({ maxresults: maxResults, sort: 'addedAt:desc', libtype: 'photo' }, Photo);
+  }
+
+  /** Returns recently added photo albums from this library section. */
+  override async recentlyAdded(maxResults = 50): Promise<Photoalbum[]> {
+    return this.recentlyAddedAlbums(maxResults);
   }
 }
 

--- a/src/photo.ts
+++ b/src/photo.ts
@@ -1,0 +1,362 @@
+import { URLSearchParams } from 'node:url';
+
+import { PartialPlexObject } from './base/partialPlexObject.js';
+import { Playable } from './base/playable.js';
+import { PlexObject } from './base/plexObject.js';
+import { fetchItem, findItems, type ItemFilterValue } from './baseFunctionality.js';
+import { NotFound } from './exceptions.js';
+import { Field, Image, Tag } from './media.js';
+import type {
+  PhotoalbumData,
+  PhotoData,
+  PhotoMediaData,
+  PhotoMetadataResponse,
+  PhotoPartData,
+} from './photo.types.js';
+import type { MediaContainer } from './util.js';
+import { Clip } from './video.js';
+
+function parseOptionalDate(value: number | string | undefined): Date | undefined {
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+
+  if (typeof value === 'number' || /^\d+$/.test(value)) {
+    return new Date(Number(value) * 1000);
+  }
+
+  return new Date(value);
+}
+
+function parseOptionalNumber(value: number | string | undefined): number | undefined {
+  if (value === undefined || value === '') {
+    return undefined;
+  }
+
+  return Number(value);
+}
+
+function isAlbumMetadata(item: Record<string, unknown>): boolean {
+  return item.type === 'photo' && String(item.key ?? '').endsWith('/children');
+}
+
+function isPhotoMetadata(item: Record<string, unknown>): boolean {
+  return item.type === 'photo' && !isAlbumMetadata(item);
+}
+
+async function fetchPhotoChildren<T>({
+  cls,
+  containerKeys,
+  fallback,
+  key,
+  options,
+  parent,
+}: {
+  cls: new (...args: any[]) => T;
+  containerKeys: string[];
+  fallback: (item: Record<string, unknown>) => boolean;
+  key: string;
+  options?: Record<string, ItemFilterValue>;
+  parent: PartialPlexObject;
+}): Promise<T[]> {
+  const response = await parent.server.query<MediaContainer<Record<string, any[]>>>({ path: key });
+  const container = response.MediaContainer;
+  const typedItems = containerKeys.flatMap(containerKey => container[containerKey] ?? []);
+  const fallbackItems = (container.Metadata ?? []).filter(fallback);
+  const items = typedItems.length > 0 ? typedItems : fallbackItems;
+  return findItems(items, options, cls, parent.server, parent);
+}
+
+export class Photoalbum extends PartialPlexObject {
+  static override TAG = 'Directory';
+  static override TYPE = 'photo';
+  static readonly SEARCH_TYPE = 'photoalbum';
+
+  declare addedAt?: Date;
+  declare art?: string;
+  declare composite?: string;
+  declare fields: Field[];
+  declare guid?: string;
+  declare images: Image[];
+  declare index?: number;
+  declare lastRatedAt?: Date;
+  declare librarySectionKey?: string;
+  declare librarySectionTitle?: string;
+  listType = 'photo' as const;
+  declare summary?: string;
+  declare thumb?: string;
+  declare titleSort?: string;
+  declare updatedAt?: Date;
+  declare userRating?: number;
+
+  async album(title: string): Promise<Photoalbum> {
+    const [album] = await this.albums({ title__iexact: title });
+    if (!album) {
+      throw new NotFound(`Unable to find photo album with title "${title}".`);
+    }
+
+    return album;
+  }
+
+  async albums(options?: Record<string, string | number>): Promise<Photoalbum[]> {
+    const key = this._buildQueryKey(`${this.key}/children`);
+    return fetchPhotoChildren<Photoalbum>({
+      cls: Photoalbum,
+      containerKeys: ['Directory'],
+      fallback: isAlbumMetadata,
+      key,
+      options,
+      parent: this,
+    });
+  }
+
+  async photo(title: string): Promise<Photo> {
+    const [photo] = await this.photos({ title__iexact: title });
+    if (!photo) {
+      throw new NotFound(`Unable to find photo with title "${title}".`);
+    }
+
+    return photo;
+  }
+
+  async photos(options?: Record<string, string | number>): Promise<Photo[]> {
+    const key = this._buildQueryKey(`${this.key}/children`);
+    return fetchPhotoChildren<Photo>({
+      cls: Photo,
+      containerKeys: ['Photo'],
+      fallback: isPhotoMetadata,
+      key,
+      options,
+      parent: this,
+    });
+  }
+
+  async clip(title: string): Promise<Clip> {
+    const [clip] = await this.clips({ title__iexact: title });
+    if (!clip) {
+      throw new NotFound(`Unable to find clip with title "${title}".`);
+    }
+
+    return clip;
+  }
+
+  async clips(options?: Record<string, string | number>): Promise<Clip[]> {
+    const key = this._buildQueryKey(`${this.key}/children`);
+    return fetchPhotoChildren<Clip>({
+      cls: Clip,
+      containerKeys: ['Video'],
+      fallback: item => item.type === 'clip',
+      key,
+      options,
+      parent: this,
+    });
+  }
+
+  override getWebURL({ base }: { base?: string } = {}): string {
+    const params = new URLSearchParams({ key: this.key, legacy: '1' });
+    return this.server._buildWebURL({ base, endpoint: 'details', params });
+  }
+
+  protected override _loadFullData(data: PhotoMetadataResponse<PhotoalbumData>): void {
+    this._loadData(data.Metadata[0]);
+  }
+
+  protected override _loadData(data: PhotoalbumData): void {
+    this.addedAt = parseOptionalDate(data.addedAt);
+    this.art = data.art;
+    this.composite = data.composite;
+    this.fields = data.Field?.map(d => new Field(this.server, d, undefined, this)) ?? [];
+    this.guid = data.guid;
+    this.images = data.Image?.map(d => new Image(this.server, d, undefined, this)) ?? [];
+    this.index = parseOptionalNumber(data.index);
+    this.key = (data.key ?? '').replace('/children', '');
+    this.lastRatedAt = parseOptionalDate(data.lastRatedAt);
+    this.librarySectionID = parseOptionalNumber(data.librarySectionID);
+    this.librarySectionKey = data.librarySectionKey;
+    this.librarySectionTitle = data.librarySectionTitle;
+    this.ratingKey = data.ratingKey?.toString();
+    this.summary = data.summary;
+    this.thumb = data.thumb;
+    this.title = data.title;
+    this.titleSort = data.titleSort ?? data.title;
+    this.type = data.type;
+    this.updatedAt = parseOptionalDate(data.updatedAt);
+    this.userRating = parseOptionalNumber(data.userRating);
+  }
+}
+
+export class PhotoMedia extends PlexObject {
+  static override TAG = 'Media';
+
+  declare aspectRatio?: number;
+  declare bitrate?: number;
+  declare container?: string;
+  declare duration?: number;
+  declare height?: number;
+  declare id?: number;
+  declare optimizedForStreaming?: boolean;
+  declare parts: PhotoPart[];
+  declare videoCodec?: string;
+  declare videoFrameRate?: string;
+  declare videoProfile?: string;
+  declare width?: number;
+
+  protected override _loadData(data: PhotoMediaData): void {
+    this.aspectRatio = parseOptionalNumber(data.aspectRatio);
+    this.bitrate = parseOptionalNumber(data.bitrate);
+    this.container = data.container;
+    this.duration = parseOptionalNumber(data.duration);
+    this.height = parseOptionalNumber(data.height);
+    this.id = parseOptionalNumber(data.id);
+    this.optimizedForStreaming =
+      data.optimizedForStreaming === true ||
+      data.optimizedForStreaming === 1 ||
+      data.optimizedForStreaming === '1';
+    this.parts = data.Part?.map(part => new PhotoPart(this.server, part, undefined, this)) ?? [];
+    this.videoCodec = data.videoCodec;
+    this.videoFrameRate = data.videoFrameRate;
+    this.videoProfile = data.videoProfile;
+    this.width = parseOptionalNumber(data.width);
+  }
+}
+
+export class PhotoPart extends PlexObject {
+  static override TAG = 'Part';
+
+  declare container?: string;
+  declare duration?: number;
+  declare file?: string;
+  declare id?: number;
+  declare size?: number;
+  declare videoProfile?: string;
+
+  originalUrl(): string | undefined {
+    return this.key ? this.server.url(this.key, { includeToken: true }).toString() : undefined;
+  }
+
+  protected override _loadData(data: PhotoPartData): void {
+    this.container = data.container;
+    this.duration = parseOptionalNumber(data.duration);
+    this.file = data.file;
+    this.id = parseOptionalNumber(data.id);
+    this.key = data.key;
+    this.size = parseOptionalNumber(data.size);
+    this.videoProfile = data.videoProfile;
+  }
+}
+
+export class Photo extends Playable {
+  static override TAG = 'Photo';
+  static override TYPE = 'photo';
+  static readonly METADATA_TYPE = 'photo';
+
+  declare addedAt?: Date;
+  declare createdAtAccuracy?: string;
+  declare createdAtTZOffset?: number;
+  declare fields: Field[];
+  declare guid?: string;
+  declare images: Image[];
+  declare index?: number;
+  declare lastRatedAt?: Date;
+  declare librarySectionKey?: string;
+  declare librarySectionTitle?: string;
+  listType = 'photo' as const;
+  declare media: PhotoMedia[];
+  declare originallyAvailableAt?: Date;
+  declare parentGuid?: string;
+  declare parentIndex?: number;
+  declare parentKey?: string;
+  declare parentRatingKey?: number;
+  declare parentThumb?: string;
+  declare parentTitle?: string;
+  declare sourceURI?: string;
+  declare summary?: string;
+  declare tags: Tag[];
+  declare thumb?: string;
+  declare titleSort?: string;
+  declare updatedAt?: Date;
+  declare userRating?: number;
+
+  get locations(): string[] {
+    return this.media
+      .flatMap(media => media.parts)
+      .map(part => part.file)
+      .filter(Boolean);
+  }
+
+  /**
+   * Returns authenticated URLs for the original photo files exposed by Plex.
+   * This does not download files or write to disk.
+   */
+  originalUrls(): string[] {
+    return this.media
+      .flatMap(media => media.parts)
+      .map(part => part.originalUrl())
+      .filter(Boolean)
+      .map(url => url);
+  }
+
+  /**
+   * Returns the first authenticated original file URL, when Plex exposes one.
+   * This does not download files or write to disk.
+   */
+  originalUrl(): string | undefined {
+    return this.originalUrls()[0];
+  }
+
+  async photoalbum(): Promise<Photoalbum> {
+    if (!this.parentKey) {
+      throw new Error('Missing parentKey to fetch photo album');
+    }
+
+    const key = this._buildQueryKey(this.parentKey);
+    const data = await fetchItem(this.server, key);
+    return new Photoalbum(this.server, data, this.parentKey, this);
+  }
+
+  override getWebURL({ base }: { base?: string } = {}): string {
+    const params = new URLSearchParams({
+      key: this.parentKey ?? this.key,
+      legacy: '1',
+    });
+    return this.server._buildWebURL({ base, endpoint: 'details', params });
+  }
+
+  protected override _loadFullData(data: PhotoMetadataResponse<PhotoData>): void {
+    this._loadData(data.Metadata[0]);
+  }
+
+  protected override _loadData(data: PhotoData): void {
+    this.addedAt = parseOptionalDate(data.addedAt);
+    this.createdAtAccuracy = data.createdAtAccuracy;
+    this.createdAtTZOffset = parseOptionalNumber(data.createdAtTZOffset);
+    this.fields = data.Field?.map(d => new Field(this.server, d, undefined, this)) ?? [];
+    this.guid = data.guid;
+    this.images = data.Image?.map(d => new Image(this.server, d, undefined, this)) ?? [];
+    this.index = parseOptionalNumber(data.index);
+    this.key = data.key;
+    this.lastRatedAt = parseOptionalDate(data.lastRatedAt);
+    this.librarySectionID = parseOptionalNumber(data.librarySectionID);
+    this.librarySectionKey = data.librarySectionKey;
+    this.librarySectionTitle = data.librarySectionTitle;
+    this.media = data.Media?.map(d => new PhotoMedia(this.server, d, undefined, this)) ?? [];
+    this.originallyAvailableAt = parseOptionalDate(data.originallyAvailableAt);
+    this.parentGuid = data.parentGuid;
+    this.parentIndex = parseOptionalNumber(data.parentIndex);
+    this.parentKey = data.parentKey;
+    this.parentRatingKey = parseOptionalNumber(data.parentRatingKey);
+    this.parentThumb = data.parentThumb;
+    this.parentTitle = data.parentTitle;
+    this.ratingKey = data.ratingKey?.toString();
+    this.sourceURI = data.source;
+    this.summary = data.summary;
+    this.tags = data.Tag?.map(d => new Tag(this.server, d, undefined, this)) ?? [];
+    this.thumb = data.thumb;
+    this.title = data.title;
+    this.titleSort = data.titleSort ?? data.title;
+    this.type = data.type;
+    this.updatedAt = parseOptionalDate(data.updatedAt);
+    this.userRating = parseOptionalNumber(data.userRating);
+    this.year = parseOptionalNumber(data.year);
+  }
+}

--- a/src/photo.types.ts
+++ b/src/photo.types.ts
@@ -1,0 +1,90 @@
+import type { MediaTagData } from './video.types.js';
+
+export type PhotoItemType = 'photo';
+
+export interface PhotoalbumData {
+  addedAt?: number | string;
+  art?: string;
+  composite?: string;
+  guid?: string;
+  index?: number | string;
+  key: string;
+  lastRatedAt?: number | string;
+  librarySectionID?: number | string;
+  librarySectionKey?: string;
+  librarySectionTitle?: string;
+  ratingKey?: number | string;
+  summary?: string;
+  thumb?: string;
+  title: string;
+  titleSort?: string;
+  type: PhotoItemType;
+  updatedAt?: number | string;
+  userRating?: number | string;
+  Field?: Array<{ locked?: boolean | number | string; name: string }>;
+  Image?: Array<{ alt?: string; type?: string; url?: string }>;
+}
+
+export interface PhotoData {
+  addedAt?: number | string;
+  createdAtAccuracy?: string;
+  createdAtTZOffset?: number | string;
+  guid?: string;
+  index?: number | string;
+  key: string;
+  lastRatedAt?: number | string;
+  librarySectionID?: number | string;
+  librarySectionKey?: string;
+  librarySectionTitle?: string;
+  originallyAvailableAt?: string;
+  parentGuid?: string;
+  parentIndex?: number | string;
+  parentKey?: string;
+  parentRatingKey?: number | string;
+  parentThumb?: string;
+  parentTitle?: string;
+  ratingKey?: number | string;
+  source?: string;
+  summary?: string;
+  thumb?: string;
+  title: string;
+  titleSort?: string;
+  type: PhotoItemType;
+  updatedAt?: number | string;
+  userRating?: number | string;
+  year?: number | string;
+  Field?: Array<{ locked?: boolean | number | string; name: string }>;
+  Image?: Array<{ alt?: string; type?: string; url?: string }>;
+  Media?: PhotoMediaData[];
+  Tag?: MediaTagData[];
+}
+
+export interface PhotoMediaData {
+  id?: number | string;
+  duration?: number | string;
+  bitrate?: number | string;
+  width?: number | string;
+  height?: number | string;
+  aspectRatio?: number | string;
+  audioCodec?: string;
+  videoCodec?: string;
+  videoFrameRate?: string;
+  videoProfile?: string;
+  container?: string;
+  optimizedForStreaming?: boolean | number | string;
+  Part?: PhotoPartData[];
+}
+
+export interface PhotoPartData {
+  id?: number | string;
+  key?: string;
+  duration?: number | string;
+  file?: string;
+  size?: number | string;
+  container?: string;
+  videoProfile?: string;
+}
+
+export interface PhotoMetadataResponse<T> {
+  Metadata: T[];
+}

--- a/test/photo.spec.ts
+++ b/test/photo.spec.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  Clip,
+  Library,
+  NotFound,
+  Photo,
+  PhotoMedia,
+  PhotoPart,
+  Photoalbum,
+  PhotoSection,
+  Unsupported,
+  type PlexServer,
+} from '../src/index.js';
+
+const photoSectionData = {
+  uuid: 'photo-section-uuid',
+  key: '3',
+  agent: 'com.plexapp.agents.none',
+  allowSync: true,
+  art: '/:/resources/photo-fanart.jpg',
+  composite: '/library/sections/3/composite',
+  filters: true,
+  language: 'en-US',
+  Location: [{ id: 1, path: '/data/Photos' }],
+  refreshing: false,
+  scanner: 'Plex Photo Scanner',
+  thumb: '/:/resources/photo.png',
+  title: 'Photos',
+  type: 'photo',
+  updatedAt: 1,
+  createdAt: 1,
+  scannedAt: 1,
+};
+
+const photoAlbumData = {
+  addedAt: 1,
+  composite: '/library/metadata/30/composite/1',
+  guid: 'local://30',
+  key: '/library/metadata/30',
+  librarySectionID: 3,
+  librarySectionKey: '/library/sections/3',
+  librarySectionTitle: 'Photos',
+  ratingKey: 30,
+  summary: 'A test album',
+  thumb: '/library/metadata/30/thumb/1',
+  title: 'Test Album',
+  type: 'photo',
+  updatedAt: 1,
+  Field: [{ name: 'title', locked: '0' }],
+  Image: [{ type: 'coverPoster', url: '/library/metadata/30/thumb/1' }],
+};
+
+const photoData = {
+  addedAt: 1,
+  guid: 'com.plexapp.agents.none://31?lang=xn',
+  index: 1,
+  key: '/library/metadata/31',
+  librarySectionID: 3,
+  librarySectionKey: '/library/sections/3',
+  librarySectionTitle: 'Photos',
+  originallyAvailableAt: '2026-01-01',
+  parentGuid: 'local://30',
+  parentIndex: 1,
+  parentKey: '/library/metadata/30',
+  parentRatingKey: 30,
+  parentThumb: '/library/metadata/30/thumb/1',
+  parentTitle: 'Test Album',
+  ratingKey: 31,
+  summary: 'A test photo',
+  thumb: '/library/metadata/31/thumb/1',
+  title: 'Cute Cat',
+  type: 'photo',
+  updatedAt: 1,
+  userRating: 8,
+  year: 2026,
+  Field: [{ name: 'title', locked: '1' }],
+  Image: [{ type: 'snapshot', url: '/library/metadata/31/thumb/1' }],
+  Media: [
+    {
+      aspectRatio: 1.5,
+      audioChannels: 0,
+      bitrate: 100,
+      duration: 0,
+      height: 800,
+      id: 300,
+      has64bitOffsets: false,
+      optimizedForStreaming: false,
+      videoCodec: 'jpeg',
+      videoFrameRate: '',
+      videoProfile: '',
+      width: 1200,
+      Part: [
+        {
+          container: 'jpeg',
+          duration: 0,
+          file: '/data/Photos/Cute Cat.jpg',
+          id: 301,
+          key: '/library/parts/301/file.jpg',
+          optimizedForStreaming: false,
+          size: 12_345,
+          videoProfile: '',
+        },
+      ],
+    },
+  ],
+  Tag: [{ tag: 'favorite' }],
+};
+
+const clipData = {
+  ...photoData,
+  key: '/library/metadata/32',
+  ratingKey: 32,
+  title: 'Photo Clip',
+  type: 'clip',
+};
+
+const photoFilterMeta = {
+  Type: [
+    {
+      active: true,
+      key: '/library/sections/3/all?type=13',
+      title: 'Photos',
+      type: 'photo',
+      Sort: [{ key: 'addedAt', title: 'Date Added', defaultDirection: 'desc' }],
+      Field: [],
+      Filter: [],
+    },
+    {
+      active: true,
+      key: '/library/sections/3/all?type=14',
+      title: 'Albums',
+      type: 'photoalbum',
+      Sort: [{ key: 'addedAt', title: 'Date Added', defaultDirection: 'desc' }],
+      Field: [],
+      Filter: [],
+    },
+  ],
+  FieldType: [],
+};
+
+function createServer(responses: Map<string, unknown>): PlexServer {
+  return {
+    query: vi.fn(({ path }: { path: string }) =>
+      Promise.resolve(responses.get(path) ?? { MediaContainer: { Metadata: [] } }),
+    ),
+    url: vi.fn((path: string, { includeToken }: { includeToken?: boolean } = {}) => {
+      const url = new URL(path, 'http://plex.test');
+      if (includeToken) {
+        url.searchParams.set('X-Plex-Token', 'token');
+      }
+
+      return url;
+    }),
+    _buildWebURL: vi.fn(
+      ({ base = 'https://app.plex.tv/desktop', endpoint, params }) =>
+        `${base}/#!/${endpoint}?${params.toString()}`,
+    ),
+  } as unknown as PlexServer;
+}
+
+function createPhotoSection() {
+  const responses = new Map<string, unknown>([
+    [
+      '/library/sections/3/all?includeMeta=1&includeAdvanced=1&X-Plex-Container-Start=0&X-Plex-Container-Size=0',
+      { MediaContainer: { Meta: [photoFilterMeta] } },
+    ],
+    [
+      '/library/sections/3/all?includeGuids=1&type=14&X-Plex-Container-Size=1',
+      { MediaContainer: { Directory: [photoAlbumData] } },
+    ],
+    [
+      '/library/sections/3/all?includeGuids=1&type=13&X-Plex-Container-Size=1',
+      { MediaContainer: { Photo: [photoData] } },
+    ],
+    [
+      '/library/sections/3/all?includeGuids=1&sort=photo.addedAt%3Adesc&type=13&X-Plex-Container-Size=1',
+      { MediaContainer: { Photo: [photoData] } },
+    ],
+  ]);
+  const server = createServer(responses);
+  const section = new PhotoSection(server, photoSectionData);
+  return { query: server.query as ReturnType<typeof vi.fn>, section };
+}
+
+describe('Photo libraries', () => {
+  it('instantiates photo sections from library section discovery', async () => {
+    const responses = new Map<string, unknown>([
+      [
+        '/library/sections',
+        {
+          MediaContainer: {
+            Directory: [photoSectionData],
+          },
+        },
+      ],
+    ]);
+    const server = createServer(responses);
+    const library = new Library(server, {
+      size: 1,
+      allowSync: true,
+      art: '',
+      content: '',
+      identifier: 'com.plexapp.plugins.library',
+      mediaTagPrefix: '/system/bundle/media/flags/',
+      mediaTagVersion: 1,
+      title1: 'Plex Library',
+      title2: '',
+      Directory: [],
+    });
+
+    const sections = await library.sections();
+
+    expect(sections[0]).toBeInstanceOf(PhotoSection);
+    expect(sections[0].type).toBe('photo');
+  });
+
+  it('searches photo albums with the photoalbum search type', async () => {
+    const { query, section } = createPhotoSection();
+
+    const albums = await section.searchAlbums({ maxresults: 1 });
+
+    expect(albums[0]).toBeInstanceOf(Photoalbum);
+    expect(albums[0].title).toBe('Test Album');
+    expect(query).toHaveBeenCalledWith({
+      path: '/library/sections/3/all?includeGuids=1&type=14&X-Plex-Container-Size=1',
+    });
+  });
+
+  it('searches photos with the photo search type', async () => {
+    const { query, section } = createPhotoSection();
+
+    const photos = await section.searchPhotos({ maxresults: 1 });
+
+    expect(photos[0]).toBeInstanceOf(Photo);
+    expect(photos[0].title).toBe('Cute Cat');
+    expect(query).toHaveBeenCalledWith({
+      path: '/library/sections/3/all?includeGuids=1&type=13&X-Plex-Container-Size=1',
+    });
+  });
+
+  it('returns recently added photos with typed photo results', async () => {
+    const { query, section } = createPhotoSection();
+
+    const photos = await section.recentlyAddedPhotos(1);
+
+    expect(photos[0]).toBeInstanceOf(Photo);
+    expect(query).toHaveBeenCalledWith({
+      path: '/library/sections/3/all?includeGuids=1&sort=photo.addedAt%3Adesc&type=13&X-Plex-Container-Size=1',
+    });
+  });
+
+  it('rejects collections for photo libraries', async () => {
+    const { section } = createPhotoSection();
+
+    await expect(section.collections()).rejects.toThrow(Unsupported);
+  });
+
+  it('returns typed children from photo albums', async () => {
+    const responses = new Map<string, unknown>([
+      [
+        '/library/metadata/30/children?includeGuids=1',
+        {
+          MediaContainer: {
+            Directory: [photoAlbumData],
+            Photo: [photoData],
+            Video: [clipData],
+          },
+        },
+      ],
+    ]);
+    const server = createServer(responses);
+    const album = new Photoalbum(server, photoAlbumData);
+
+    const albums = await album.albums();
+    const photos = await album.photos();
+    const clips = await album.clips();
+
+    expect(albums[0]).toBeInstanceOf(Photoalbum);
+    expect(photos[0]).toBeInstanceOf(Photo);
+    expect(clips[0]).toBeInstanceOf(Clip);
+  });
+
+  it('returns typed children from collapsed metadata responses', async () => {
+    const responses = new Map<string, unknown>([
+      [
+        '/library/metadata/30/children?includeGuids=1',
+        {
+          MediaContainer: {
+            Metadata: [
+              { ...photoAlbumData, key: '/library/metadata/30/children' },
+              photoData,
+              clipData,
+            ],
+          },
+        },
+      ],
+    ]);
+    const server = createServer(responses);
+    const album = new Photoalbum(server, photoAlbumData);
+
+    const albums = await album.albums();
+    const photos = await album.photos();
+    const clips = await album.clips();
+
+    expect(albums[0]).toBeInstanceOf(Photoalbum);
+    expect(photos[0]).toBeInstanceOf(Photo);
+    expect(clips[0]).toBeInstanceOf(Clip);
+  });
+
+  it('rejects missing photo album children with not found errors', async () => {
+    const responses = new Map<string, unknown>([
+      [
+        '/library/metadata/30/children?includeGuids=1',
+        {
+          MediaContainer: {
+            Photo: [photoData],
+          },
+        },
+      ],
+    ]);
+    const server = createServer(responses);
+    const album = new Photoalbum(server, photoAlbumData);
+
+    await expect(album.photo('Missing')).rejects.toThrow(NotFound);
+  });
+
+  it('maps photo file locations and original urls from media parts', () => {
+    const server = createServer(new Map());
+    const photo = new Photo(server, photoData);
+
+    expect(photo.media[0]).toBeInstanceOf(PhotoMedia);
+    expect(photo.media[0].parts[0]).toBeInstanceOf(PhotoPart);
+    expect(photo.locations).toEqual(['/data/Photos/Cute Cat.jpg']);
+    expect(photo.originalUrl()).toBe(
+      'http://plex.test/library/parts/301/file.jpg?X-Plex-Token=token',
+    );
+  });
+});


### PR DESCRIPTION
Photo sections were not being returned from Library.sections() because we only instantiated movie, show, and music sections. This adds typed PhotoSection, Photoalbum, and Photo support so photo libraries can be searched and navigated like the other library types.

This keeps the API URL-first instead of adding filesystem download helpers. Photos expose original part URLs, albums can fetch nested albums/photos/clips, and photo collections explicitly throw since Plex does not support collections for photo libraries.

Also adds optional photo setup to the test bootstrap and mocked tests around the response shapes.