### PR TITLE
feat(library): Add manual filter metadata

### DIFF
--- a/src/library.ts
+++ b/src/library.ts
@@ -484,10 +484,14 @@ type SearchBuildResult = {
 type SearchParamEntry = [string, string];
 type SearchFilterField = Pick<FilteringField, 'key' | 'type'>;
 type LibrarySearchMetadata = { type?: Libtype } & Record<string, unknown>;
+type ManualFilteringField = Pick<FilteringFieldData, 'key' | 'title' | 'type'>;
+type ManualFilteringFilter = Pick<FilteringFilterData, 'filter' | 'filterType' | 'title'>;
+type ManualFilteringSort = Pick<FilteringSortData, 'defaultDirection' | 'key' | 'title'>;
 const FILTER_VALUE_TYPES = [
   'audioLanguage',
   'boolean',
   'date',
+  'guid',
   'integer',
   'resolution',
   'string',
@@ -599,6 +603,156 @@ function createLibrarySearchItem(
   }
 
   return new Cls(server, data, undefined, parent) as LibrarySearchItem;
+}
+
+function addUniqueByKey<T extends { key: string }>(items: T[], additions: T[]): T[] {
+  const existingKeys = new Set(items.map(item => item.key));
+  return [...items, ...additions.filter(item => !existingKeys.has(item.key))];
+}
+
+function manualFilteringFields(libtype: string): ManualFilteringField[] {
+  const prefix = libtype === 'movie' ? '' : `${libtype}.`;
+  const fields: ManualFilteringField[] = [
+    { key: `${prefix}guid`, title: 'Guid', type: 'guid' },
+    { key: `${prefix}id`, title: 'Rating Key', type: 'integer' },
+    {
+      key: `${prefix}index`,
+      title: `${libtype[0].toUpperCase()}${libtype.slice(1)} Number`,
+      type: 'integer',
+    },
+    {
+      key: `${prefix}lastRatedAt`,
+      title: `${libtype[0].toUpperCase()}${libtype.slice(1)} Last Rated`,
+      type: 'date',
+    },
+    { key: `${prefix}updatedAt`, title: 'Date Updated', type: 'date' },
+    { key: 'group', title: 'SQL Group By Statement', type: 'string' },
+    { key: 'having', title: 'SQL Having Clause', type: 'string' },
+  ];
+
+  switch (libtype) {
+    case 'movie': {
+      fields.push(
+        { key: 'audienceRating', title: 'Audience Rating', type: 'integer' },
+        { key: 'rating', title: 'Critic Rating', type: 'integer' },
+        { key: 'viewOffset', title: 'View Offset', type: 'integer' },
+      );
+      break;
+    }
+
+    case 'show': {
+      fields.push(
+        { key: 'show.audienceRating', title: 'Audience Rating', type: 'integer' },
+        { key: 'show.originallyAvailableAt', title: 'Show Release Date', type: 'date' },
+        { key: 'show.rating', title: 'Critic Rating', type: 'integer' },
+        { key: 'show.unviewedLeafCount', title: 'Episode Unplayed Count', type: 'integer' },
+      );
+      break;
+    }
+
+    case 'season': {
+      fields.push(
+        { key: 'season.addedAt', title: 'Date Season Added', type: 'date' },
+        { key: 'season.unviewedLeafCount', title: 'Episode Unplayed Count', type: 'integer' },
+        { key: 'season.year', title: 'Season Year', type: 'integer' },
+        { key: 'season.label', title: 'Label', type: 'tag' },
+      );
+      break;
+    }
+
+    case 'episode': {
+      fields.push(
+        { key: 'episode.audienceRating', title: 'Audience Rating', type: 'integer' },
+        { key: 'episode.duration', title: 'Duration', type: 'integer' },
+        { key: 'episode.rating', title: 'Critic Rating', type: 'integer' },
+        { key: 'episode.viewOffset', title: 'View Offset', type: 'integer' },
+        { key: 'episode.label', title: 'Label', type: 'tag' },
+      );
+      break;
+    }
+
+    case 'artist': {
+      fields.push({ key: 'artist.label', title: 'Label', type: 'tag' });
+      break;
+    }
+
+    case 'track': {
+      fields.push(
+        { key: 'track.duration', title: 'Duration', type: 'integer' },
+        { key: 'track.viewOffset', title: 'View Offset', type: 'integer' },
+        { key: 'track.label', title: 'Label', type: 'tag' },
+        { key: 'track.ratingCount', title: 'Rating Count', type: 'integer' },
+      );
+      break;
+    }
+
+    case 'collection': {
+      fields.push(
+        { key: 'collection.addedAt', title: 'Date Added', type: 'date' },
+        { key: 'collection.label', title: 'Label', type: 'tag' },
+      );
+      break;
+    }
+  }
+
+  return fields;
+}
+
+function manualFilteringFilters(libtype: string, sectionKey?: string): FilteringFilterData[] {
+  const filterTypes: Record<string, ManualFilteringFilter[]> = {
+    artist: [{ filter: 'label', filterType: 'string', title: 'Labels' }],
+    collection: [{ filter: 'label', filterType: 'string', title: 'Labels' }],
+    episode: [{ filter: 'label', filterType: 'string', title: 'Labels' }],
+    season: [{ filter: 'label', filterType: 'string', title: 'Labels' }],
+    track: [{ filter: 'label', filterType: 'string', title: 'Labels' }],
+  };
+  return (filterTypes[libtype] ?? []).map(filter => ({
+    ...filter,
+    key: `/library/sections/${sectionKey ?? ''}/${filter.filter}?type=${searchType(libtype)}`,
+    type: 'filter',
+  }));
+}
+
+function manualFilteringSorts(libtype: string): FilteringSortData[] {
+  const sorts: ManualFilteringSort[] = [
+    { defaultDirection: 'asc', key: 'guid', title: 'Guid' },
+    { defaultDirection: 'asc', key: 'id', title: 'Rating Key' },
+    {
+      defaultDirection: 'asc',
+      key: 'index',
+      title: `${libtype[0].toUpperCase()}${libtype.slice(1)} Number`,
+    },
+    { defaultDirection: 'asc', key: 'summary', title: 'Summary' },
+    { defaultDirection: 'asc', key: 'tagline', title: 'Tagline' },
+    { defaultDirection: 'asc', key: 'updatedAt', title: 'Date Updated' },
+  ];
+
+  switch (libtype) {
+    case 'season': {
+      sorts.push({ defaultDirection: 'asc', key: 'titleSort', title: 'Title' });
+      break;
+    }
+
+    case 'track': {
+      sorts.push({ defaultDirection: 'asc', key: 'absoluteIndex', title: 'Absolute Index' });
+      break;
+    }
+
+    case 'photo': {
+      sorts.push({ defaultDirection: 'desc', key: 'viewUpdatedAt', title: 'View Updated At' });
+      break;
+    }
+
+    case 'collection': {
+      sorts.push({ defaultDirection: 'asc', key: 'addedAt', title: 'Date Added' });
+      break;
+    }
+  }
+
+  return sorts.map(sort => ({
+    ...sort,
+    descKey: `${sort.key}:desc`,
+  }));
 }
 
 /**
@@ -1473,6 +1627,16 @@ export abstract class LibrarySection<SType = SectionType> extends PlexObject {
     this._fieldTypes = (meta?.FieldType ?? []).map(
       fieldType => new FilteringFieldType(this.server, fieldType, undefined, this),
     );
+    if (!this._fieldTypes.some(fieldType => fieldType.type === 'guid')) {
+      this._fieldTypes.push(
+        new FilteringFieldType(
+          this.server,
+          { type: 'guid', Operator: [{ key: '=', title: 'is' }] },
+          undefined,
+          this,
+        ),
+      );
+    }
   }
 
   /**
@@ -1605,6 +1769,11 @@ export abstract class LibrarySection<SType = SectionType> extends PlexObject {
           }
 
           case 'string': {
+            result = String(value);
+            break;
+          }
+
+          case 'guid': {
             result = String(value);
             break;
           }
@@ -2674,12 +2843,17 @@ export class FilteringType extends PlexObject {
 
   _loadData(data: FilteringTypeData) {
     this.active = parsePlexBoolean(data.active);
-    this.fields = (data.Field ?? []).map(d => new FilteringField(this.server, d, undefined, this));
-    this.filters = (data.Filter ?? []).map(
-      d => new FilteringFilter(this.server, d, undefined, this),
+    const section = this.parent?.deref() as LibrarySection | undefined;
+    const fields = addUniqueByKey(data.Field ?? [], manualFilteringFields(data.type));
+    const filters = addUniqueByKey(
+      data.Filter ?? [],
+      manualFilteringFilters(data.type, section?.key),
     );
+    const sorts = addUniqueByKey(data.Sort ?? [], manualFilteringSorts(data.type));
+    this.fields = fields.map(d => new FilteringField(this.server, d, undefined, this));
+    this.filters = filters.map(d => new FilteringFilter(this.server, d, undefined, this));
     this.key = data.key;
-    this.sorts = (data.Sort ?? []).map(d => new FilteringSort(this.server, d, undefined, this));
+    this.sorts = sorts.map(d => new FilteringSort(this.server, d, undefined, this));
     this.title = data.title;
     this.type = data.type;
   }

--- a/src/library.ts
+++ b/src/library.ts
@@ -605,12 +605,20 @@ function createLibrarySearchItem(
   return new Cls(server, data, undefined, parent) as LibrarySearchItem;
 }
 
+// Plex filter metadata is incomplete on some servers. Keep server-provided
+// entries first and append manual entries only when the key is missing.
 function addUniqueByKey<T extends { key: string }>(items: T[], additions: T[]): T[] {
   const existingKeys = new Set(items.map(item => item.key));
   return [...items, ...additions.filter(item => !existingKeys.has(item.key))];
 }
 
+/**
+ * Fields accepted by Plex search but not reliably advertised in filter metadata.
+ * This mirrors Python PlexAPI's manual field list without constructing XML.
+ */
 function manualFilteringFields(libtype: string): ManualFilteringField[] {
+  // Python sends movie manual fields without a `movie.` prefix; other libtypes
+  // need the libtype prefix for Plex to accept them.
   const prefix = libtype === 'movie' ? '' : `${libtype}.`;
   const fields: ManualFilteringField[] = [
     { key: `${prefix}guid`, title: 'Guid', type: 'guid' },
@@ -698,6 +706,10 @@ function manualFilteringFields(libtype: string): ManualFilteringField[] {
   return fields;
 }
 
+/**
+ * Label choice endpoints exist for these secondary libtypes even when Plex
+ * leaves them out of the advertised filter menu metadata.
+ */
 function manualFilteringFilters(libtype: string, sectionKey?: string): FilteringFilterData[] {
   const filterTypes: Record<string, ManualFilteringFilter[]> = {
     artist: [{ filter: 'label', filterType: 'string', title: 'Labels' }],
@@ -713,6 +725,9 @@ function manualFilteringFilters(libtype: string, sectionKey?: string): Filtering
   }));
 }
 
+/**
+ * Sorts accepted by Plex search but often omitted from the advertised sort list.
+ */
 function manualFilteringSorts(libtype: string): FilteringSortData[] {
   const sorts: ManualFilteringSort[] = [
     { defaultDirection: 'asc', key: 'guid', title: 'Guid' },
@@ -1627,6 +1642,9 @@ export abstract class LibrarySection<SType = SectionType> extends PlexObject {
     this._fieldTypes = (meta?.FieldType ?? []).map(
       fieldType => new FilteringFieldType(this.server, fieldType, undefined, this),
     );
+    // Plex accepts `guid` as a search field, but does not advertise a guid field
+    // type. Add minimal operator metadata so validation can treat it like the
+    // server-advertised field types.
     if (!this._fieldTypes.some(fieldType => fieldType.type === 'guid')) {
       this._fieldTypes.push(
         new FilteringFieldType(
@@ -2844,6 +2862,8 @@ export class FilteringType extends PlexObject {
   _loadData(data: FilteringTypeData) {
     this.active = parsePlexBoolean(data.active);
     const section = this.parent?.deref() as LibrarySection | undefined;
+    // Merge hidden-but-valid metadata into the server response here so list and
+    // validation helpers expose the same augmented view.
     const fields = addUniqueByKey(data.Field ?? [], manualFilteringFields(data.type));
     const filters = addUniqueByKey(
       data.Filter ?? [],

--- a/test/library-helpers.spec.ts
+++ b/test/library-helpers.spec.ts
@@ -123,6 +123,15 @@ const genreChoices = [
   { fastKey: '/library/sections/1/all?genre=2&type=1', key: '2', title: 'Comedy', type: 'genre' },
 ];
 
+const labelChoices = [
+  {
+    fastKey: '/library/sections/2/all?label=99&type=4',
+    key: '99',
+    title: 'Favorite',
+    type: 'label',
+  },
+];
+
 const collectionData = {
   childCount: 1,
   key: '/library/metadata/99',
@@ -249,6 +258,43 @@ function createMovieSection() {
   const section = new MovieSection(server, movieSectionData);
   sections.push(section);
   return { history, query, section };
+}
+
+function createShowSection() {
+  const filterMeta = {
+    Type: [
+      {
+        active: true,
+        key: '/library/sections/2/all?type=4',
+        title: 'Episodes',
+        type: 'episode',
+        Field: [],
+        Filter: [],
+        Sort: [],
+      },
+    ],
+    FieldType: [
+      {
+        type: 'tag',
+        Operator: [
+          { key: '=', title: 'is' },
+          { key: '!=', title: 'is not' },
+        ],
+      },
+    ],
+  };
+  const responses = new Map<string, unknown>([
+    [
+      '/library/sections/2/all?includeMeta=1&includeAdvanced=1&X-Plex-Container-Start=0&X-Plex-Container-Size=0',
+      { MediaContainer: { Meta: [filterMeta] } },
+    ],
+    ['/library/sections/2/label?type=4', { MediaContainer: { Directory: labelChoices } }],
+  ]);
+  const query = vi.fn(({ path }: { path: string }) =>
+    Promise.resolve(responses.get(path) ?? { MediaContainer: { Metadata: [] } }),
+  );
+  const section = new ShowSection({ query } as unknown as PlexServer, showSectionData);
+  return { query, section };
 }
 
 function lastQueryPath(query: ReturnType<typeof vi.fn>): string {
@@ -531,7 +577,68 @@ describe('LibrarySection search filters', () => {
 
     expect(lastQueryEntries(query)).toEqual([
       ['includeGuids', '1'],
-      ['movie.id', '99'],
+      ['id', '99'],
+    ]);
+  });
+
+  it('adds manual filter fields and guid operators missing from plex metadata', async () => {
+    const { query, section } = createMovieSection();
+
+    const fields = await section.listFields();
+    const fieldTypes = await section.fieldTypes();
+    await section.search({
+      filters: {
+        guid: 'plex://movie/123',
+        viewOffset: 10,
+      },
+    });
+
+    expect(fields.map(field => field.key)).toEqual(
+      expect.arrayContaining([
+        'guid',
+        'id',
+        'lastRatedAt',
+        'updatedAt',
+        'viewOffset',
+        'group',
+        'having',
+      ]),
+    );
+    expect(fieldTypes.find(fieldType => fieldType.type === 'guid')?.operators[0].key).toBe('=');
+    expect(lastQueryEntries(query)).toEqual([
+      ['includeGuids', '1'],
+      ['guid', 'plex://movie/123'],
+      ['viewOffset', '10'],
+    ]);
+  });
+
+  it('adds manual sort fields missing from plex metadata', async () => {
+    const { query, section } = createMovieSection();
+
+    const sorts = await section.listSorts();
+    await section.search({ sort: 'guid:desc' });
+
+    expect(sorts.map(sort => sort.key)).toEqual(
+      expect.arrayContaining(['guid', 'id', 'updatedAt']),
+    );
+    expect(lastQueryEntries(query)).toEqual([
+      ['includeGuids', '1'],
+      ['sort', 'movie.guid:desc'],
+    ]);
+  });
+
+  it('adds manual label filters for episode searches', async () => {
+    const { query, section } = createShowSection();
+
+    const filters = await section.listFilters('episode');
+    await section.searchEpisodes({ filters: { label: 'Favorite' } });
+
+    expect(filters.map(filter => filter.filter)).toContain('label');
+    expect(query).toHaveBeenCalledWith({ path: '/library/sections/2/label?type=4' });
+    expect(lastQueryEntries(query)).toEqual([
+      ['includeGuids', '1'],
+      ['type', '4'],
+      ['episode.label', '99'],
     ]);
   });
 


### PR DESCRIPTION
Adds the hidden Plex search metadata that Python PlexAPI carries by hand when the server does not advertise it. That includes guid/id/date fields, a few per-libtype fields, manual sort keys, and label filters for secondary libtypes like episodes and tracks.

This keeps validation strict while still allowing searches Plex accepts, instead of rejecting valid filters just because the metadata endpoint left them out.

Adds mocked coverage for guid filters, manual sorts, and episode label choices so the query keys stay aligned with Plex/Python behavior.