### PR TITLE
feat(library): Add hub helper APIs

### DIFF
--- a/src/library.ts
+++ b/src/library.ts
@@ -420,6 +420,19 @@ export interface PlaylistSearchOptions {
   [filter: string]: ItemFilterValue | undefined;
 }
 
+export interface ManagedHubVisibilityOptions {
+  /** Show or hide this hub on the library Recommended tab. */
+  recommended?: boolean;
+  /** Show or hide this hub on the owner's Home page. */
+  home?: boolean;
+  /** Show or hide this hub on shared users' Home pages. */
+  shared?: boolean;
+}
+
+type RequireAtLeastOne<T> = {
+  [K in keyof T]-?: Required<Pick<T, K>> & Partial<Omit<T, K>>;
+}[keyof T];
+export type ManagedHubVisibilityChanges = RequireAtLeastOne<ManagedHubVisibilityOptions>;
 export type SectionAdvancedSettings = Record<string, SettingValue>;
 export type LibrarySectionHistoryOptions = Omit<HistoryOptions, 'librarySectionId'>;
 
@@ -483,7 +496,7 @@ type SearchBuildResult = {
 };
 type SearchParamEntry = [string, string];
 type SearchFilterField = Pick<FilteringField, 'key' | 'type'>;
-type LibrarySearchMetadata = { type?: Libtype } & Record<string, unknown>;
+type LibrarySearchMetadata = { type?: string };
 type ManualFilteringField = Pick<FilteringFieldData, 'key' | 'title' | 'type'>;
 type ManualFilteringFilter = Pick<FilteringFilterData, 'filter' | 'filterType' | 'title'>;
 type ManualFilteringSort = Pick<FilteringSortData, 'defaultDirection' | 'key' | 'title'>;
@@ -544,7 +557,7 @@ function reverseSearchType(type: string | number | null): Libtype | undefined {
   return entry?.[0] as Libtype | undefined;
 }
 
-function classForLibtype(libtype?: Libtype): Class<LibrarySearchItem> | undefined {
+function classForLibtype(libtype?: string): Class<LibrarySearchItem> | undefined {
   switch (libtype) {
     case 'movie': {
       return Movie;
@@ -603,6 +616,19 @@ function createLibrarySearchItem(
   }
 
   return new Cls(server, data, undefined, parent) as LibrarySearchItem;
+}
+
+function createHubItem<T extends LibrarySearchItem>(
+  server: PlexServer,
+  data: LibrarySearchMetadata,
+  parent: PlexObject,
+  Cls?: Class<T>,
+): T {
+  if (Cls) {
+    return new Cls(server, data, undefined, parent);
+  }
+
+  return createLibrarySearchItem(server, data, parent) as T;
 }
 
 // Plex filter metadata is incomplete on some servers. Keep server-provided
@@ -2388,6 +2414,55 @@ export class ManagedHub extends PlexObject {
     await this.server.query({ path: key, method: 'delete' });
   }
 
+  /**
+   * Update where this managed hub is visible.
+   * Omitted flags preserve the hub's current visibility state.
+   */
+  async updateVisibility(changes: ManagedHubVisibilityChanges): Promise<this> {
+    const {
+      recommended = this.promotedToRecommended,
+      home = this.promotedToOwnHome,
+      shared = this.promotedToSharedHome,
+    } = changes;
+    const params = new URLSearchParams({
+      promotedToRecommended: recommended ? '1' : '0',
+      promotedToOwnHome: home ? '1' : '0',
+      promotedToSharedHome: shared ? '1' : '0',
+    });
+    const key = `/hubs/sections/${this.librarySectionID}/manage/${
+      this.identifier
+    }?${params.toString()}`;
+    await this.server.query({ path: key, method: 'put' });
+    this.promotedToRecommended = recommended;
+    this.promotedToOwnHome = home;
+    this.promotedToSharedHome = shared;
+    return this;
+  }
+
+  promoteRecommended(): Promise<this> {
+    return this.updateVisibility({ recommended: true });
+  }
+
+  demoteRecommended(): Promise<this> {
+    return this.updateVisibility({ recommended: false });
+  }
+
+  promoteHome(): Promise<this> {
+    return this.updateVisibility({ home: true });
+  }
+
+  demoteHome(): Promise<this> {
+    return this.updateVisibility({ home: false });
+  }
+
+  promoteShared(): Promise<this> {
+    return this.updateVisibility({ shared: true });
+  }
+
+  demoteShared(): Promise<this> {
+    return this.updateVisibility({ shared: false });
+  }
+
   protected _loadData(data: ManagedHubData): void {
     this.deletable = parsePlexBoolean(data.deletable, true);
     this.homeVisibility = data.homeVisibility ?? 'none';
@@ -2408,24 +2483,86 @@ export class ManagedHub extends PlexObject {
 export class Hub extends PlexObject {
   static override TAG = 'Hub';
 
+  declare context?: string;
+  declare hubKey?: string;
   declare hubIdentifier: string;
+  declare librarySectionID?: string;
+  /** True if Plex has more items available at this hub's key. */
+  declare more: boolean;
   /** Number of items found. */
   declare size: number;
+  declare style?: string;
   declare title: string;
   declare type: string;
   /** True if the hub items are randomized. */
   declare random: boolean;
   declare Directory: SearchResultContainer['Directory'];
   declare Metadata: SearchResultContainer['Metadata'];
+  declare private _metadata?: LibrarySearchMetadata[];
+  declare private _items?: LibrarySearchItem[];
+
+  /**
+   * Return items from this hub.
+   *
+   * Plex often includes a partial `Metadata` list with the hub response. When
+   * `more` is true, this fetches the hub key first so callers get the full item
+   * list instead of only the preview items.
+   */
+  async items(): Promise<LibrarySearchItem[]>;
+  async items<T extends LibrarySearchItem>(Cls: Class<T>): Promise<T[]>;
+  async items<T extends LibrarySearchItem>(Cls?: Class<T>): Promise<LibrarySearchItem[] | T[]> {
+    if (this.more && this.key) {
+      const data = await this.server.query<MediaContainer<{ Metadata?: LibrarySearchMetadata[] }>>({
+        path: this._buildQueryKey(this.key),
+      });
+      this._metadata = data.MediaContainer.Metadata ?? [];
+      this._items = undefined;
+      this.more = false;
+      this.size = this._metadata.length;
+    }
+
+    if (Cls) {
+      return (this._metadata ?? []).map(item => createHubItem(this.server, item, this, Cls));
+    }
+
+    if (!this._items) {
+      this._items = (this._metadata ?? []).map(item => createHubItem(this.server, item, this));
+    }
+
+    return this._items as T[];
+  }
+
+  async section(): Promise<Section> {
+    const parent = this.parent?.deref();
+    if (parent instanceof LibrarySection) {
+      return parent as Section;
+    }
+
+    const sectionID = this.librarySectionID;
+    if (!sectionID) {
+      throw new NotFound(`Unable to find library section for hub "${this.title}".`);
+    }
+
+    const library = await this.server.library();
+    return library.sectionByID(sectionID);
+  }
 
   protected _loadData(data: SearchResultContainer) {
+    this.context = data.context;
+    this.hubKey = data.hubKey;
     this.hubIdentifier = data.hubIdentifier;
+    this.key = data.key ?? data.hubKey ?? '';
+    this.librarySectionID = data.librarySectionID?.toString();
+    this.more = parsePlexBoolean(data.more);
     this.size = data.size;
+    this.style = data.style;
     this.title = data.title;
     this.type = data.type;
     this.random = parsePlexBoolean(data.random);
     this.Directory = data.Directory;
     this.Metadata = data.Metadata;
+    this._metadata = data.Metadata ?? [];
+    this._items = undefined;
   }
 }
 

--- a/src/library.ts
+++ b/src/library.ts
@@ -438,6 +438,7 @@ export type LibrarySectionHistoryOptions = Omit<HistoryOptions, 'librarySectionI
 
 export type SectionType = Movie | Show | Artist | Album | Track | Photoalbum;
 export type LibrarySearchItem = SectionType | Season | Episode | Photo | Collections;
+export type HubItem = LibrarySearchItem | Playlist;
 type RatingKeyItem = { ratingKey?: number | string };
 type SearchTagValue = { id: number | string; tag?: string } | { id?: number | string; tag: string };
 export type SearchFilterPrimitive =
@@ -618,7 +619,7 @@ function createLibrarySearchItem(
   return new Cls(server, data, undefined, parent) as LibrarySearchItem;
 }
 
-function createHubItem<T extends LibrarySearchItem>(
+function createHubItem<T extends HubItem>(
   server: PlexServer,
   data: LibrarySearchMetadata,
   parent: PlexObject,
@@ -626,6 +627,10 @@ function createHubItem<T extends LibrarySearchItem>(
 ): T {
   if (Cls) {
     return new Cls(server, data, undefined, parent);
+  }
+
+  if (data.type === 'station' || data.type === 'playlist') {
+    return new Playlist(server, data, undefined, parent) as T;
   }
 
   return createLibrarySearchItem(server, data, parent) as T;
@@ -2499,7 +2504,7 @@ export class Hub extends PlexObject {
   declare Directory: SearchResultContainer['Directory'];
   declare Metadata: SearchResultContainer['Metadata'];
   declare private _metadata?: LibrarySearchMetadata[];
-  declare private _items?: LibrarySearchItem[];
+  declare private _items?: HubItem[];
 
   /**
    * Return items from this hub.
@@ -2508,9 +2513,9 @@ export class Hub extends PlexObject {
    * `more` is true, this fetches the hub key first so callers get the full item
    * list instead of only the preview items.
    */
-  async items(): Promise<LibrarySearchItem[]>;
-  async items<T extends LibrarySearchItem>(Cls: Class<T>): Promise<T[]>;
-  async items<T extends LibrarySearchItem>(Cls?: Class<T>): Promise<LibrarySearchItem[] | T[]> {
+  async items(): Promise<HubItem[]>;
+  async items<T extends HubItem>(Cls: Class<T>): Promise<T[]>;
+  async items<T extends HubItem>(Cls?: Class<T>): Promise<HubItem[] | T[]> {
     if (this.more && this.key) {
       const data = await this.server.query<MediaContainer<{ Metadata?: LibrarySearchMetadata[] }>>({
         path: this._buildQueryKey(this.key),

--- a/src/search.types.ts
+++ b/src/search.types.ts
@@ -10,8 +10,11 @@ export interface MatchSearchResult {
 export interface SearchResultContainer {
   title: string;
   type: string;
+  key?: string;
+  hubKey?: string;
   hubIdentifier: string;
   context: string;
+  librarySectionID?: number | string;
   size: number;
   more: boolean;
   random?: boolean | number | string;

--- a/test/library-helpers.spec.ts
+++ b/test/library-helpers.spec.ts
@@ -6,6 +6,7 @@ import {
   Movie,
   MovieSection,
   NotFound,
+  Playlist,
   Setting,
   ShowSection,
   type EditableLibraryItem,
@@ -186,6 +187,21 @@ const managedHubData = {
   title: 'On Deck',
 };
 
+const stationData = {
+  addedAt: 1,
+  composite: '/station/composite',
+  guid: 'station://1',
+  key: '/library/metadata/1/station/radio',
+  leafCount: 1,
+  playlistType: 'audio',
+  ratingKey: 'station-1',
+  smart: false,
+  summary: 'Artist radio',
+  title: 'Artist Radio',
+  type: 'station',
+  updatedAt: 1,
+};
+
 function createMovieSection() {
   const createCollectionParams = new URLSearchParams({
     title: 'Test Collection',
@@ -283,6 +299,18 @@ function createMovieSection() {
               title: 'More Hub',
               type: 'movie',
               Metadata: [hubMovieData],
+            },
+            {
+              context: 'hub.music.stations',
+              hubIdentifier: 'hub.music.stations',
+              key: '/hubs/sections/1/stations',
+              librarySectionID: '1',
+              more: false,
+              size: 1,
+              style: 'shelf',
+              title: 'Stations',
+              type: 'station',
+              Metadata: [stationData],
             },
           ],
         },
@@ -611,6 +639,16 @@ describe('Hub helpers', () => {
     expect(hubs[1].more).toBe(false);
     expect(hubs[1].size).toBe(1);
     expect(query).toHaveBeenCalledWith({ path: '/hubs/sections/1/more?includeGuids=1' });
+  });
+
+  it('returns station hub items as playlists', async () => {
+    const { section } = createMovieSection();
+
+    const hubs = await section.hubs();
+    const items = await hubs[2].items();
+
+    expect(items[0]).toBeInstanceOf(Playlist);
+    expect(items[0].title).toBe('Artist Radio');
   });
 });
 

--- a/test/library-helpers.spec.ts
+++ b/test/library-helpers.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   BadRequest,
+  ManagedHub,
   Movie,
   MovieSection,
   NotFound,
@@ -156,6 +157,35 @@ const playlistData = {
   updatedAt: 1,
 };
 
+const hubMovieData = {
+  addedAt: 1,
+  key: '/library/metadata/10',
+  ratingKey: '10',
+  summary: 'A movie from a hub.',
+  thumb: '/library/metadata/10/thumb',
+  title: 'Hub Movie',
+  type: 'movie',
+};
+
+const fetchedHubMovieData = {
+  ...hubMovieData,
+  key: '/library/metadata/11',
+  ratingKey: '11',
+  title: 'Fetched Hub Movie',
+};
+
+const managedHubData = {
+  deletable: 1,
+  homeVisibility: 'all',
+  identifier: 'com.plexapp.plugins.library.onDeck',
+  librarySectionID: '1',
+  promotedToOwnHome: 1,
+  promotedToRecommended: 0,
+  promotedToSharedHome: 0,
+  recommendationsVisibility: 'none',
+  title: 'On Deck',
+};
+
 function createMovieSection() {
   const createCollectionParams = new URLSearchParams({
     title: 'Test Collection',
@@ -224,6 +254,52 @@ function createMovieSection() {
           ],
         },
       },
+    ],
+    [
+      '/hubs/sections/1?includeGuids=1&includeStations=1',
+      {
+        MediaContainer: {
+          Hub: [
+            {
+              context: 'hub.library',
+              hubIdentifier: 'movie.inline',
+              key: '/hubs/sections/1/inline',
+              librarySectionID: '1',
+              more: false,
+              size: 1,
+              style: 'shelf',
+              title: 'Inline Hub',
+              type: 'movie',
+              Metadata: [hubMovieData],
+            },
+            {
+              context: 'hub.library',
+              hubIdentifier: 'movie.more',
+              key: '/hubs/sections/1/more',
+              librarySectionID: '1',
+              more: true,
+              size: 2,
+              style: 'shelf',
+              title: 'More Hub',
+              type: 'movie',
+              Metadata: [hubMovieData],
+            },
+          ],
+        },
+      },
+    ],
+    [
+      '/hubs/sections/1/more?includeGuids=1',
+      { MediaContainer: { Metadata: [fetchedHubMovieData] } },
+    ],
+    ['/hubs/sections/1/manage', { MediaContainer: { Hub: [managedHubData] } }],
+    [
+      '/hubs/sections/1/manage/com.plexapp.plugins.library.onDeck?promotedToRecommended=1&promotedToOwnHome=1&promotedToSharedHome=1',
+      { MediaContainer: {} },
+    ],
+    [
+      '/hubs/sections/1/manage/com.plexapp.plugins.library.onDeck?promotedToRecommended=0&promotedToOwnHome=1&promotedToSharedHome=1',
+      { MediaContainer: {} },
     ],
     [
       `/library/collections?${createCollectionParams.toString()}`,
@@ -505,6 +581,69 @@ describe('LibrarySection edit helpers', () => {
 
     await expect(section.common(item)).rejects.toThrow(BadRequest);
     expect(query).not.toHaveBeenCalled();
+  });
+});
+
+describe('Hub helpers', () => {
+  it('returns typed items from inline hub metadata', async () => {
+    const { query, section } = createMovieSection();
+
+    const hubs = await section.hubs();
+    const items = await hubs[0].items();
+    const hubSection = await hubs[0].section();
+
+    expect(items[0]).toBeInstanceOf(Movie);
+    expect(items[0].title).toBe('Hub Movie');
+    expect(hubSection).toBe(section);
+    expect(query).toHaveBeenCalledWith({
+      path: '/hubs/sections/1?includeGuids=1&includeStations=1',
+    });
+  });
+
+  it('fetches typed items when a hub has more results', async () => {
+    const { query, section } = createMovieSection();
+
+    const hubs = await section.hubs();
+    const items = await hubs[1].items();
+
+    expect(items[0]).toBeInstanceOf(Movie);
+    expect(items[0].title).toBe('Fetched Hub Movie');
+    expect(hubs[1].more).toBe(false);
+    expect(hubs[1].size).toBe(1);
+    expect(query).toHaveBeenCalledWith({ path: '/hubs/sections/1/more?includeGuids=1' });
+  });
+});
+
+describe('ManagedHub helpers', () => {
+  it('updates managed hub visibility with typed helpers', async () => {
+    const { query, section } = createMovieSection();
+
+    const hubs = await section.managedHubs();
+    const hub = await hubs[0].updateVisibility({ recommended: true, shared: true });
+
+    expect(hub).toBeInstanceOf(ManagedHub);
+    expect(hub.promotedToRecommended).toBe(true);
+    expect(hub.promotedToOwnHome).toBe(true);
+    expect(hub.promotedToSharedHome).toBe(true);
+    expect(query).toHaveBeenCalledWith({
+      path: '/hubs/sections/1/manage/com.plexapp.plugins.library.onDeck?promotedToRecommended=1&promotedToOwnHome=1&promotedToSharedHome=1',
+      method: 'put',
+    });
+  });
+
+  it('supports managed hub visibility convenience methods', async () => {
+    const { query, section } = createMovieSection();
+
+    const hubs = await section.managedHubs();
+    const hub = await hubs[0].promoteShared();
+
+    expect(hub.promotedToRecommended).toBe(false);
+    expect(hub.promotedToOwnHome).toBe(true);
+    expect(hub.promotedToSharedHome).toBe(true);
+    expect(query).toHaveBeenCalledWith({
+      path: '/hubs/sections/1/manage/com.plexapp.plugins.library.onDeck?promotedToRecommended=0&promotedToOwnHome=1&promotedToSharedHome=1',
+      method: 'put',
+    });
   });
 });
 


### PR DESCRIPTION
Hubs had the raw metadata but no typed way to load the items behind them. This adds Hub.items() so inline metadata is instantiated and hubs with more fetch their full key first.

Also adds managed hub visibility helpers with a typed options object and convenience methods for recommended, home, and shared visibility.